### PR TITLE
SWIK-537 Reposition (drag) absolute elements from PPTX2HTML import

### DIFF
--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -154,27 +154,38 @@ class SlideContentEditor extends React.Component {
         //let simpledraggable =
         //../../../../../../assets/ckeditor_config.js
         //require('../../../../../assets/simple-draggable.js');
-        /*
-        require('../../../../../custom_modules/simple-draggable/lib/index.js');
-        //SimpleDraggable('div.draggable', {
+        if(process.env.BROWSER){
 
-        SimpleDraggable('div.draggable', {
-            onlyX: false
-          , onlyY: false
-          , onStart: function (event, element) {
-                // Do something on drag start
-                console.log('dragging start');
-          }
-          , onStop: function (event, element) {
-                // Do something on drag stop
-                console.log('dragging stop');
-          }
-          , onDrag: function (event, element) {
-                // Do something on drag drag
-                console.log('dragging element');
-          }
-        });
-        */
+        //require('../../../../../custom_modules/simple-draggable/lib/index.js');
+        //SimpleDraggable('div.draggable', {
+        //test on: http://localhost:3000/deck/344-2/slide/1397-1/1397-1:10/edit
+        //SimpleDraggable('.pptx2html.div.draggable', {
+        //SimpleDraggable('.div.draggable', {
+        //alert($('.pptx2html.div').css("position"));
+        //alert($('.pptx2html .block').css("position"));
+            if ($('.pptx2html .block').css('position') === 'absolute')
+            {/*add border*/ $('.pptx2html .block')
+                .css({'borderStyle': 'dashed dashed none dashed', 'borderColor': '#33cc33'});
+            }
+
+            //SimpleDraggable('.pptx2html .block', {
+            SimpleDraggable('.block', {
+                onlyX: false
+              , onlyY: false
+              , onStart: function (event, element) {
+                  // Do something on drag start
+                  console.log('dragging start');
+              }
+              , onStop: function (event, element) {
+                  // Do something on drag stop
+                  console.log('dragging stop');
+              }
+              , onDrag: function (event, element) {
+                  // Do something on drag drag
+                  console.log('dragging element');
+              }
+            });
+        }
         //based on querySelectorAll (selects based on class of elements - get all children + apply draggable x & y positioning)
         //TODO: remove surrounding DIVS of some PPTX2HTML output elements
         //########Works well with following PPTX2HTML output:

--- a/components/DefaultHTMLLayout.js
+++ b/components/DefaultHTMLLayout.js
@@ -36,6 +36,7 @@ class DefaultHTMLLayout extends React.Component {
                 {/* All external vendors bundle*/}
                 <script src="/public/js/vendor.bundle.js"></script>
                 <script src="/custom_modules/ckeditor/ckeditor.js"></script>
+                <script src="/custom_modules/simple-draggable/lib/index.js"></script>
                 <script type="javascript">
                     //CKEDITOR.disableAutoInline = false; //need to disable auto-initate to config inline toolbars
                     CKEDITOR.disableAutoInline = true; //need to disable auto-initate to config inline toolbars


### PR DESCRIPTION
Also addresses SWIK-489 - Create border around divs in edit mode for
clearly showing draggable elements