### PR TITLE
SWIK534 ClassName of UserNotificationsBadge change to ui item

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -25,7 +25,7 @@ class Header extends React.Component {
                         <NavLink className="ui item" routeName="addDeck" activeClass="active">
                             <AddDeckPanel />
                         </NavLink>
-                        <UserNotificationsBadge className="zi item"/>
+                        <UserNotificationsBadge className="ui item"/>
                         <LoginModal className="ui item"/>
                     </div>
                 </div>


### PR DESCRIPTION
In components/Header.js, at line 28, tehre is a typo in the className assigned to UserNotificationsBadge. The line is:
 ` <UserNotificationsBadge className="zi item"/>`
It should be:

 ` <UserNotificationsBadge className="ui item"/>`