### PR TITLE
Swik 573 show activities for selected slide/deck

### DIFF
--- a/components/Deck/ActivityFeedPanel/ActivityItem.js
+++ b/components/Deck/ActivityFeedPanel/ActivityItem.js
@@ -22,7 +22,7 @@ class ActivityItem extends React.Component {
             fontStyle: 'italic',
             fontWeight: 400
         };
-        const viewPath = ((node.content_kind === 'slide') ? '/slideview/' : '/deckview/') + node.content_id;
+        const viewPath = ((node.content_kind === 'slide') ? '/deck/' + this.props.selector.id + '/slide/' : '/deck/') + node.content_id;
         switch (node.activity_type) {
             case 'translate':
                 IconNode = (<i className="ui big translate icon"></i>);

--- a/components/Deck/ActivityFeedPanel/ActivityItem.js
+++ b/components/Deck/ActivityFeedPanel/ActivityItem.js
@@ -23,6 +23,8 @@ class ActivityItem extends React.Component {
             fontWeight: 400
         };
         const viewPath = ((node.content_kind === 'slide') ? '/deck/' + this.props.selector.id + '/slide/' : '/deck/') + node.content_id;
+        const nodeRef = (node.content_kind === this.props.selector.stype && node.content_id === this.props.selector.sid) ? (<span> {'this ' + node.content_kind} </span>) :
+            (<span>{node.content_kind + ' '}<a href={viewPath}>{node.content_name}</a></span>);
         switch (node.activity_type) {
             case 'translate':
                 IconNode = (<i className="ui big translate icon"></i>);
@@ -30,8 +32,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'translated ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>{' to '}
+                        </a> {'translated '} {nodeRef} {' to '}
                         {/*<a href={'/slideview/' + node.translation_info.content_id}>{node.translation_info.language}</a>*/}
                         <a href={viewPath}>{node.translation_info.language}</a>
                         <br/>
@@ -45,8 +46,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'shared ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>{' on '}
+                        </a> {'shared '} {nodeRef} {' on '}
                         <a target="_blank" href={node.share_info.postURI}>{node.share_info.platform}</a>
                         <br/>
                         {DateDiv}
@@ -59,8 +59,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'created ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'created '} {nodeRef}
                         <br/>
                         {DateDiv}
                     </div>
@@ -72,8 +71,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'edited ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'edited '} {nodeRef}
                         <br/>
                         {DateDiv}
                     </div>
@@ -85,8 +83,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'commented on ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'commented on '} {nodeRef}
                         <br/>
                         <span style={commentStyles}>{'"' + node.comment_info.text + '"'}</span>
                         <br/>
@@ -101,8 +98,7 @@ class ActivityItem extends React.Component {
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
                         </a>
-                        <span> replied to a comment </span>{'on ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        <span> replied to a comment </span>{'on ' } {nodeRef}
                         <br/>
                         <span style={commentStyles}>{'"' + node.comment_info.text + '"'}</span>
                         <br/>
@@ -116,8 +112,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'used ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'used '} {nodeRef}
                         {' in deck '}<a href={'/deckview/' + node.use_info.target_id}>{node.use_info.target_name}</a>
                         <br/>
                         {DateDiv}
@@ -130,8 +125,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'rated ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'rated '} {nodeRef}
                         <br/>
                         {DateDiv}
                     </div>
@@ -143,8 +137,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'liked ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'liked '} {nodeRef}
                         <br/>
                         {DateDiv}
                     </div>
@@ -156,8 +149,7 @@ class ActivityItem extends React.Component {
                     <div className="summary">
                         <a className="user" href={'/user/' + node.user_id}>
                             {node.author ? node.author.username : 'unknown'}
-                        </a> {'downloaded ' + node.content_kind + ' '}
-                        <a href={viewPath}>{node.content_name}</a>
+                        </a> {'downloaded '} {nodeRef}
                         <br/>
                         {DateDiv}
                     </div>

--- a/components/Deck/ActivityFeedPanel/ActivityList.js
+++ b/components/Deck/ActivityFeedPanel/ActivityList.js
@@ -71,6 +71,13 @@ class ActivityList extends React.Component {
         //        </div>
         //    );
         //});
+
+        if (this.props.ActivityFeedStore.activities.length === 0) {
+            return (
+                <div>There are currently no activities for this {this.props.ActivityFeedStore.selector.stype}.</div>
+            )
+        }
+
         const listStyles = {
             maxHeight: '400px',
             overflowY: 'auto'

--- a/components/Deck/ActivityFeedPanel/ActivityList.js
+++ b/components/Deck/ActivityFeedPanel/ActivityList.js
@@ -9,7 +9,7 @@ class ActivityList extends React.Component {
     renderItem(index, key) {
         return (
             <div className="ui item" key={key} style={{ margin: '1em 0'}}>
-                <ActivityItem activity={this.props.ActivityFeedStore.activities[index]} />
+                <ActivityItem selector={this.props.ActivityFeedStore.selector} activity={this.props.ActivityFeedStore.activities[index]} />
             </div>
         );
     }

--- a/services/activities.js
+++ b/services/activities.js
@@ -63,13 +63,14 @@ export default {
         let selector= {'id': args.id, 'spath': args.spath, 'sid': args.sid, 'stype': args.stype, 'mode': args.mode};
 
         // const content_id = (!selector.sid.startsWith('1122334455')) ? ('112233445566778899000000'.substring(0, 24 - selector.sid.length) + selector.sid) : selector.sid;//TODO solve these ID issues
+        const content_kind = selector.stype;
         const content_id = selector.sid;
         switch (resource) {
             case 'activities.list':
 
                 // callback(null, {activities: initialActivities.concat(generateRandomActivities(30, 11)), selector: selector, hasMore: true});
 
-                rp.get({uri: Microservices.activities.uri + '/activities/' + content_id + '/more/0/30' }).then((res) => {
+                rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/0/30' }).then((res) => {
                     let activities = JSON.parse(res);
 
                     activities.forEach((activity) => adjustIDs(activity));//TODO solve these ID issues
@@ -93,7 +94,7 @@ export default {
                 //     callback(null, {activities: newActivities, hasMore: hasMoreActivities});
                 // }, 500);
 
-                rp.get({uri: Microservices.activities.uri + '/activities/' + content_id + '/more/' + params.newActivities.start + '/' + params.newActivities.numNew }).then((res) => {
+                rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/' + params.newActivities.start + '/' + params.newActivities.numNew }).then((res) => {
                     let activities = JSON.parse(res);
 
                     activities.forEach((activity) => adjustIDs(activity));//TODO solve these ID issues


### PR DESCRIPTION
Activity feed now shows activities for the selected slide/deck.
If a deck is selected, activities for its subdecks and slides are also shown.
Most of the code changes to enable this were done on the activity-service.
This branch also solves problems with slide/deck links (SWIK-596).