### PR TITLE
SWIK 550  Make slide content fit in slide view and edit component

### DIFF
--- a/components/Deck/ActivityFeedPanel/ActivityList.js
+++ b/components/Deck/ActivityFeedPanel/ActivityList.js
@@ -28,7 +28,7 @@ class ActivityList extends React.Component {
     }
     componentDidMount() {
         this.loading = false;
-        this.refs.activityList.addEventListener('scroll', this.onScroll.bind(this));
+        //this.refs.activityList.addEventListener('scroll', this.onScroll.bind(this));
     }
     componentWillReceiveProps(nextProps) {
         // TODO: same as in the ActivityFeedStore; check if there is more elegant way to tell the component that action loadMoreActivities (in the onScroll function) was executed

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -60,13 +60,29 @@ class SlideContentEditor extends React.Component {
     }
     componentDidMount() {
         if(process.env.BROWSER){
-            require('../../../../../bower_components/reveal.js/css/reveal.css');
+            //require('../../../../../bower_components/reveal.js/css/reveal.css');
             // Uncomment this to see with the different themes.  Assuming testing for PPTPX2HTML for now
             // Possible values: ['beige', 'black', 'blood', 'league', 'moon', 'night', 'serif', 'simple', 'sky', 'solarized', 'white']
             // require('../../../../../bower_components/reveal.js/css/theme/black.css');
             // require('../../../../../bower_components/reveal.js/css/theme/black.css');
-            require('../../SetupReveal.css');
+            //require('../../SetupReveal.css');
 
+            //Function toi fit contents in edit and view component
+            //$(".pptx2html").addClass('schaal');
+            //$(".pptx2html [style*='absolute']").addClass('schaal');
+            //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+            //$("#inlineContent").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+            if ($('.pptx2html').length)
+            {
+                $(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
+                //use algorithm for selecting all elements in simple-draggable!!
+                //z-index = z-index -999999
+                //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
+            } else {
+                //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                //$(".pptx2html").css({'z-index': ''});
+            }
 
         }
         //TODO/bug? = inline-toolbar does not resize properly when zooming in browser. Does work in example on CKeditor website..
@@ -296,10 +312,10 @@ class SlideContentEditor extends React.Component {
 
         return (
             <div>
+            <div style={headerStyle} contentEditable='true' name='inlineHeader' ref='inlineHeader' id='inlineHeader' dangerouslySetInnerHTML={{__html:this.props.title}}></div>
+            <hr />
                 <div className="reveal">
                     <div className="slides" style={revealSlideStyle}>
-                            <div style={headerStyle} contentEditable='true' name='inlineHeader' ref='inlineHeader' id='inlineHeader' dangerouslySetInnerHTML={{__html:this.props.title}}></div>
-                            <hr />
                             <div style={contentStyle} contentEditable='true' name='inlineContent' ref='inlineContent' id='inlineContent' dangerouslySetInnerHTML={{__html:this.props.content}}></div>
                     </div>
                 </div>

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -10,6 +10,8 @@ import SlideEditStore from '../../../../../stores/SlideEditStore';
 import addSlide from '../../../../../actions/slide/addSlide';
 import saveSlide from '../../../../../actions/slide/saveSlide';
 import loadSlideAll from '../../../../../actions/slide/loadSlideAll';
+import ResizeAware from 'react-resize-aware';
+import { findDOMNode } from 'react-dom'
 
 let ReactDOM = require('react-dom');
 
@@ -241,13 +243,14 @@ class SlideContentEditor extends React.Component {
                 //}
             });
 
+            ReactDOM.findDOMNode(this.refs.container).addEventListener('resize', (evt) => {
+              console.log('Component has been resized!');
+          });
         //setTimeout(this.forceUpdate(), 500);
         this.forceUpdate();
 
     }
     componentDidUpdate() {
-
-
     }
     componentWillUnmount() {
         //TODO
@@ -311,7 +314,7 @@ class SlideContentEditor extends React.Component {
                     */
 
         return (
-            <div>
+            <ResizeAware ref='container' style={{position: 'relative'}}>
             <div style={headerStyle} contentEditable='true' name='inlineHeader' ref='inlineHeader' id='inlineHeader' dangerouslySetInnerHTML={{__html:this.props.title}}></div>
             <hr />
                 <div className="reveal">
@@ -327,7 +330,7 @@ class SlideContentEditor extends React.Component {
                   <div className="visible content"><i className="save icon"></i>Save</div>
                   <div tabIndex="0" className="hidden content" ><i className="save icon"></i>Save</div>
                 </button>
-            </div>
+            </ResizeAware>
 
         );
     }

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -11,7 +11,7 @@ import addSlide from '../../../../../actions/slide/addSlide';
 import saveSlide from '../../../../../actions/slide/saveSlide';
 import loadSlideAll from '../../../../../actions/slide/loadSlideAll';
 import ResizeAware from 'react-resize-aware';
-import { findDOMNode } from 'react-dom'
+import { findDOMNode } from 'react-dom';
 
 let ReactDOM = require('react-dom');
 
@@ -25,6 +25,8 @@ class SlideContentEditor extends React.Component {
         this.currentcontent;
         this.refresh = 'false';
         this.CKEDitor_loaded = false;
+        //this.props.scaleratio = 1;
+        this.scaleratio = 1;
     }
     handleSaveButton(){
 
@@ -68,23 +70,6 @@ class SlideContentEditor extends React.Component {
             // require('../../../../../bower_components/reveal.js/css/theme/black.css');
             // require('../../../../../bower_components/reveal.js/css/theme/black.css');
             //require('../../SetupReveal.css');
-
-            //Function toi fit contents in edit and view component
-            //$(".pptx2html").addClass('schaal');
-            //$(".pptx2html [style*='absolute']").addClass('schaal');
-            //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
-            //$("#inlineContent").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
-            if ($('.pptx2html').length)
-            {
-                $(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
-                //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
-                //use algorithm for selecting all elements in simple-draggable!!
-                //z-index = z-index -999999
-                //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
-            } else {
-                //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
-                //$(".pptx2html").css({'z-index': ''});
-            }
 
         }
         //TODO/bug? = inline-toolbar does not resize properly when zooming in browser. Does work in example on CKeditor website..
@@ -168,7 +153,7 @@ class SlideContentEditor extends React.Component {
                 //../../../../../../assets/ckeditor_config.js
                 //require('../../../../../assets/simple-draggable.js');
 
-                //require('../../../../../custom_modules/simple-draggable/lib/index.js');
+                require('../../../../../custom_modules/simple-draggable/lib/index.js');
 
                 if(process.env.BROWSER){
 
@@ -186,9 +171,13 @@ class SlideContentEditor extends React.Component {
                         $(".pptx2html [style*='absolute']")
                         .css({'borderStyle': 'dashed dashed dashed dashed', 'borderColor': '#33cc33'});
                     //}
+
+                    //need to remove existing event listener functions!!!
+//                    , ratio: this.props.SlideEditStore.scaleratio
                   SimpleDraggable(".pptx2html [style*='absolute']", {
                       onlyX: false
                     , onlyY: false
+                    , ratio: this.scaleratio
                   });
                 }
                 /*
@@ -241,11 +230,206 @@ class SlideContentEditor extends React.Component {
                     //alert('CKEDITOR destroyed, and content updated');
                 }*/
                 //}
+
+                //set intitial resize:
+                //TODO: make function to prevent repetition! - shared function with slide view!
+
+                    let containerwidth = document.getElementById('container').offsetWidth;
+                    let containerheight = document.getElementById('container').offsetHeight;
+                    //console.log('Component has been resized! Width =' + containerwidth + 'height' + containerheight);
+
+                    //reset scaling of pptx2html element to get original size
+                    $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+
+                    //let pptxwidth = document.getElementByClassName('pptx2html').offsetWidth;
+                    //let pptxheight = document.getElementByClassName('pptx2html').offsetHeight;
+                    let pptxwidth = $('.pptx2html').width();
+                    let pptxheight = $('.pptx2html').height();
+                    //console.log('pptx2html Width =' + pptxwidth + 'height' + pptxheight);
+
+                    //only calculate scaleration for width for now
+                    if (containerwidth > pptxwidth)
+                    {
+                        this.scaleratio = pptxwidth / containerwidth;
+                        //console.log(this.scaleratio);
+                        //this.props.SlideEditStore.scaleratio = containerwidth / pptxwidth;
+                        //let scaleratio = containerwidth / pptxwidth;
+                    } else {
+                        this.scaleratio = containerwidth / pptxwidth;
+                        //console.log(this.scaleratio);
+                        //this.props.SlideEditStore.scaleratio = pptxwidth / containerwidth;
+                        //let scaleratio = pptxwidth / containerwidth;
+                    }
+                    //Function to fit contents in edit and view component
+                    //$(".pptx2html").addClass('schaal');
+                    //$(".pptx2html [style*='absolute']").addClass('schaal');
+                    //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                    //$("#inlineContent").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                    if(process.env.BROWSER){
+                        if ($('.pptx2html').length)
+                        {
+                            //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'transform': 'scale('+scaleratio+','+scaleratio+')', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'transform': 'scale('+this.props.SlideEditStore.scaleratio+','+this.props.SlideEditStore.scaleratio+')', 'transform-origin': 'top left'});
+                            $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+                            $(".pptx2html").css({'transform': 'scale('+this.scaleratio+','+this.scaleratio+')', 'transform-origin': 'top left'});
+
+                            require('../../../../../custom_modules/simple-draggable/lib/index.js');
+
+                            //TODO: give +this.props.SlideEditStore.scaleratio to ptx2html - DONE?
+                            //TODO: remove previous event listeners!
+                            //, ratio: this.props.SlideEditStore.scaleratio
+                            SimpleDraggable(".pptx2html [style*='absolute']", {
+                                onlyX: false
+                              , onlyY: false
+                              , ratio: this.scaleratio
+                            });
+
+                            //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
+                            //use algorithm for selecting all elements in simple-draggable!!
+                            //z-index = z-index -999999
+                            //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
+                        } else {
+                            //Do nothing for slideview - is relative content - will be scaled automatically?!
+
+                            //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'z-index': ''});
+                        }
+                    }
+                    if(process.env.BROWSER){
+                        if ($('.pptx2html').length)
+                        {
+                            //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'transform': 'scale('+scaleratio+','+scaleratio+')', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'transform': 'scale('+this.props.SlideEditStore.scaleratio+','+this.props.SlideEditStore.scaleratio+')', 'transform-origin': 'top left'});
+                            $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+                            $(".pptx2html").css({'transform': 'scale('+this.scaleratio+','+this.scaleratio+')', 'transform-origin': 'top left'});
+
+                            require('../../../../../custom_modules/simple-draggable/lib/index.js');
+
+                            //TODO: give +this.props.SlideEditStore.scaleratio to ptx2html - DONE?
+                            //TODO: remove previous event listeners!
+                            //, ratio: this.props.SlideEditStore.scaleratio
+                            SimpleDraggable(".pptx2html [style*='absolute']", {
+                                onlyX: false
+                              , onlyY: false
+                              , ratio: this.scaleratio
+                            });
+
+                            //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
+                            //use algorithm for selecting all elements in simple-draggable!!
+                            //z-index = z-index -999999
+                            //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
+                        } else {
+                            //Do nothing for slideview - is relative content - will be scaled automatically?!
+
+                            //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                            //$(".pptx2html").css({'z-index': ''});
+                        }
+                    }
+
             });
 
-            ReactDOM.findDOMNode(this.refs.container).addEventListener('resize', (evt) => {
-              console.log('Component has been resized!');
-          });
+
+
+            ReactDOM.findDOMNode(this.refs.container).addEventListener('resize', (evt) =>
+                {
+                let containerwidth = document.getElementById('container').offsetWidth;
+                let containerheight = document.getElementById('container').offsetHeight;
+                //console.log('Component has been resized! Width =' + containerwidth + 'height' + containerheight);
+
+                //reset scaling of pptx2html element to get original size
+                $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+
+                //let pptxwidth = document.getElementByClassName('pptx2html').offsetWidth;
+                //let pptxheight = document.getElementByClassName('pptx2html').offsetHeight;
+                let pptxwidth = $('.pptx2html').width();
+                let pptxheight = $('.pptx2html').height();
+                //console.log('pptx2html Width =' + pptxwidth + 'height' + pptxheight);
+
+                //only calculate scaleration for width for now
+                if (containerwidth > pptxwidth)
+                {
+                    this.scaleratio = pptxwidth / containerwidth;
+                    //console.log(this.scaleratio);
+                    //this.props.SlideEditStore.scaleratio = containerwidth / pptxwidth;
+                    //let scaleratio = containerwidth / pptxwidth;
+                } else {
+                    this.scaleratio = containerwidth / pptxwidth;
+                    //console.log(this.scaleratio);
+                    //this.props.SlideEditStore.scaleratio = pptxwidth / containerwidth;
+                    //let scaleratio = pptxwidth / containerwidth;
+                }
+                //Function to fit contents in edit and view component
+                //$(".pptx2html").addClass('schaal');
+                //$(".pptx2html [style*='absolute']").addClass('schaal');
+                //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                //$("#inlineContent").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                if(process.env.BROWSER){
+                    if ($('.pptx2html').length)
+                    {
+                        //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'transform': 'scale('+scaleratio+','+scaleratio+')', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'transform': 'scale('+this.props.SlideEditStore.scaleratio+','+this.props.SlideEditStore.scaleratio+')', 'transform-origin': 'top left'});
+                        $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+                        $(".pptx2html").css({'transform': 'scale('+this.scaleratio+','+this.scaleratio+')', 'transform-origin': 'top left'});
+
+                        require('../../../../../custom_modules/simple-draggable/lib/index.js');
+
+                        //TODO: give +this.props.SlideEditStore.scaleratio to ptx2html - DONE?
+                        //TODO: remove previous event listeners!
+                        //, ratio: this.props.SlideEditStore.scaleratio
+                        SimpleDraggable(".pptx2html [style*='absolute']", {
+                            onlyX: false
+                          , onlyY: false
+                          , ratio: this.scaleratio
+                        });
+
+                        //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
+                        //use algorithm for selecting all elements in simple-draggable!!
+                        //z-index = z-index -999999
+                        //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
+                    } else {
+                        //Do nothing for slideview - is relative content - will be scaled automatically?!
+
+                        //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'z-index': ''});
+                    }
+                }
+                CKEDITOR.instances.inlineContent.on("instanceReady", function() {
+                if(process.env.BROWSER){
+                    if ($('.pptx2html').length)
+                    {
+                        //$(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'transform': 'scale('+scaleratio+','+scaleratio+')', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'transform': 'scale('+this.props.SlideEditStore.scaleratio+','+this.props.SlideEditStore.scaleratio+')', 'transform-origin': 'top left'});
+                        $(".pptx2html").css({'transform': '', 'transform-origin': ''});
+                        $(".pptx2html").css({'transform': 'scale('+this.scaleratio+','+this.scaleratio+')', 'transform-origin': 'top left'});
+
+                        require('../../../../../custom_modules/simple-draggable/lib/index.js');
+
+                        //TODO: give +this.props.SlideEditStore.scaleratio to ptx2html - DONE?
+                        //TODO: remove previous event listeners!
+                        //, ratio: this.props.SlideEditStore.scaleratio
+                        SimpleDraggable(".pptx2html [style*='absolute']", {
+                            onlyX: false
+                          , onlyY: false
+                          , ratio: this.scaleratio
+                        });
+
+                        //make z-index of pptx2html output negative for preventing overlap over CKeditor and login modal
+                        //use algorithm for selecting all elements in simple-draggable!!
+                        //z-index = z-index -999999
+                        //$(".pptx2html [style*='absolute']").css({'z-index': '-1'});
+                    } else {
+                        //Do nothing for slideview - is relative content - will be scaled automatically?!
+
+                        //$(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                        //$(".pptx2html").css({'z-index': ''});
+                    }
+                }
+            });
+            });
         //setTimeout(this.forceUpdate(), 500);
         this.forceUpdate();
 
@@ -314,7 +498,7 @@ class SlideContentEditor extends React.Component {
                     */
 
         return (
-            <ResizeAware ref='container' style={{position: 'relative'}}>
+            <ResizeAware ref='container' id='container' style={{position: 'relative'}}>
             <div style={headerStyle} contentEditable='true' name='inlineHeader' ref='inlineHeader' id='inlineHeader' dangerouslySetInnerHTML={{__html:this.props.title}}></div>
             <hr />
                 <div className="reveal">

--- a/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
@@ -34,10 +34,10 @@ class SlideViewPanel extends React.Component {
         return (
           <div className="ui bottom attached segment">
               <div ref="slideViewPanel" className="ui" style={compStyle}>
+              <div dangerouslySetInnerHTML={{__html:this.props.SlideViewStore.title}} />
                   <div className="reveal">
                       <div className="slides" style={revealSlideStyle}>
-                          <div dangerouslySetInnerHTML={{__html:this.props.SlideViewStore.title}} />
-                          <div dangerouslySetInnerHTML={{__html:this.props.SlideViewStore.content}} />
+                          <div id="inlineContent" dangerouslySetInnerHTML={{__html:this.props.SlideViewStore.content}} />
                       </div>
                   </div>
               </div>
@@ -56,7 +56,18 @@ class SlideViewPanel extends React.Component {
             // require('../../../../../bower_components/reveal.js/css/theme/black.css');
             require('../../SetupReveal.css');
 
+            //Function toi fit contents in edit and view component
+            //$(".pptx2html").addClass('schaal');
+            //$(".pptx2html [style*='absolute']").addClass('schaal');
+            if ($('.pptx2html').length)
+            {
+                $(".pptx2html").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                //$("#signinModal").css({'zIndex': '99999', 'position': 'absolute'});
 
+            } else {
+                $(".slides").css({'transform': 'scale(0.5,0.5)', 'transform-origin': 'top left'});
+                //$("#signinModal").css({'zIndex': '99999', 'position': 'absolute'});
+            }
         }
     }
 }

--- a/custom_modules/simple-draggable/lib/index.js
+++ b/custom_modules/simple-draggable/lib/index.js
@@ -42,6 +42,15 @@
         for (var i = 0; i < allElms.length; ++i) {
             (function (cEl) {
 
+                //http://stackoverflow.com/questions/9251837/how-to-remove-all-listeners-in-an-element
+                //var old_element = document.getElementById("btn");
+                //var new_element = old_element.cloneNode(true);
+                //old_element.parentNode.replaceChild(new_element, old_element);
+
+                //var old_element = document.getElementById("btn");
+                var new_element = cEl.cloneNode(true);
+                cEl.parentNode.replaceChild(new_element, cEl);
+                var cEl = new_element;
 
                 // create _simpleDraggable object for this dom element
                 // KLAAS -> added resize
@@ -49,6 +58,13 @@
                    drag: false,
                    resize: false
                 }
+
+                //TODO: remove previous event listeners:
+                //cEl.removeEventListener("mouseenter", <function>);
+                //Note: To remove event handlers, the function specified with the addEventListener() method must be an external function, like in the example above (myFunction).
+                //Anonymous functions, like "element.removeEventListener("event", function(){ myScript });" will not work.
+
+
 
                 //ondragstart="return false;" ondrop="return false;"
 
@@ -261,18 +277,18 @@
                                 return;
                             }
                             //console.log('drag');
-
                             // move only on y axis
                             if (!options.onlyY) {
-                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
-                                cEl.style.left = (cEl._simpleDraggable.elPos.x + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / 0.5 )  + "px";
+                                // use variable scale factor calculated from slide edit component size
+                                //cEl.style.left = (cEl._simpleDraggable.elPos.x + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / 0.5 )  + "px";
+                                cEl.style.left = (cEl._simpleDraggable.elPos.x + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / options.ratio )  + "px";
                                 //console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
                             }
 
                             // move only on x axis
                             if (!options.onlyX) {
-                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
-                                cEl.style.top = (cEl._simpleDraggable.elPos.y +  ( e.clientY - cEl._simpleDraggable.mousePos.y)  / 0.5 )  + "px";
+                                // use variable scale factor calculated from slide edit component size
+                                cEl.style.top = (cEl._simpleDraggable.elPos.y +  ( e.clientY - cEl._simpleDraggable.mousePos.y)  / options.ratio )  + "px";
                             }
                         } else if (cEl._simpleDraggable.resize === true)
                         {
@@ -288,8 +304,8 @@
                             if (!options.onlyY) {
                                 //calculate width as well
                                 //cEl.style.left = (cEl._simpleDraggable.elPos.x) + "px";
-                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
-                                cEl.style.width = (cEl._simpleDraggable.elDim.w  + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / 0.5 )   + "px";
+                                // use variable scale factor calculated from slide edit component size
+                                cEl.style.width = (cEl._simpleDraggable.elDim.w  + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / options.ratio )   + "px";
                             }
 
                             // resize only on x axis
@@ -298,8 +314,8 @@
                                 //cEl.style.top = (cEl._simpleDraggable.elPos.y) + "px";
                                 //console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
                                 //console.log(cEl.style.height);
-                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
-                                cEl.style.height = ((cEl._simpleDraggable.elDim.h + (e.clientY - cEl._simpleDraggable.mousePos.y) / 0.5 )  ) + "px";
+                                // use variable scale factor calculated from slide edit component size
+                                cEl.style.height = ((cEl._simpleDraggable.elDim.h + (e.clientY - cEl._simpleDraggable.mousePos.y) / options.ratio )  ) + "px";
                                 //console.log(((cEl._simpleDraggable.elDim.w + e.clientY - cEl._simpleDraggable.mousePos.y) * 2) + "px");
                                 //console.log(cEl.style.height);
                             }

--- a/custom_modules/simple-draggable/lib/index.js
+++ b/custom_modules/simple-draggable/lib/index.js
@@ -260,17 +260,19 @@
                             if (options.onDrag.call(this, e, cEl) === false) {
                                 return;
                             }
-                            console.log('drag');
+                            //console.log('drag');
 
                             // move only on y axis
                             if (!options.onlyY) {
-                                cEl.style.left = (cEl._simpleDraggable.elPos.x + e.clientX - cEl._simpleDraggable.mousePos.x) + "px";
-                                console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
+                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
+                                cEl.style.left = (cEl._simpleDraggable.elPos.x + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / 0.5 )  + "px";
+                                //console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
                             }
 
                             // move only on x axis
                             if (!options.onlyX) {
-                                cEl.style.top = (cEl._simpleDraggable.elPos.y + e.clientY - cEl._simpleDraggable.mousePos.y) + "px";
+                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
+                                cEl.style.top = (cEl._simpleDraggable.elPos.y +  ( e.clientY - cEl._simpleDraggable.mousePos.y)  / 0.5 )  + "px";
                             }
                         } else if (cEl._simpleDraggable.resize === true)
                         {
@@ -280,25 +282,28 @@
                             if (options.onDrag.call(this, e, cEl) === false) {
                                 return;
                             }
-                            console.log('resize');
+                            //console.log('resize');
 
                             // resize only on y axis
                             if (!options.onlyY) {
                                 //calculate width as well
                                 //cEl.style.left = (cEl._simpleDraggable.elPos.x) + "px";
-                                cEl.style.width = (cEl._simpleDraggable.elDim.w + e.clientX - cEl._simpleDraggable.mousePos.x) + "px";
+                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
+                                cEl.style.width = (cEl._simpleDraggable.elDim.w  + ( e.clientX - cEl._simpleDraggable.mousePos.x)  / 0.5 )   + "px";
                             }
 
                             // resize only on x axis
                             if (!options.onlyX) {
                                 ////calculate height as well:
                                 //cEl.style.top = (cEl._simpleDraggable.elPos.y) + "px";
-                                console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
-                                console.log(cEl.style.height);
-                                cEl.style.height = (cEl._simpleDraggable.elDim.h + e.clientY - cEl._simpleDraggable.mousePos.y) + "px";
-                                console.log((cEl._simpleDraggable.elDim.w + e.clientY - cEl._simpleDraggable.mousePos.y) + "px");
-                                console.log(cEl.style.height);
+                                //console.log(e.clientY - cEl._simpleDraggable.mousePos.y);
+                                //console.log(cEl.style.height);
+                                //TODO replace 0.5 by variable scale factor calculated from slide edit component size
+                                cEl.style.height = ((cEl._simpleDraggable.elDim.h + (e.clientY - cEl._simpleDraggable.mousePos.y) / 0.5 )  ) + "px";
+                                //console.log(((cEl._simpleDraggable.elDim.w + e.clientY - cEl._simpleDraggable.mousePos.y) * 2) + "px");
+                                //console.log(cEl.style.height);
                             }
+                            //cEl.style.transform = 'scale(0.5)';
                             //move resize button with resized borders of element
                             cEl.resizediv.style.left = parseInt(cEl.style.width) - 50 + "px";
                             cEl.resizediv.style.top = parseInt(cEl.style.height) - 50 + "px";

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-hotkeys": "^0.9.0",
     "react-list": "^0.8.0",
     "react-modal": "^1.4.0",
+    "react-resize-aware": "^1.0.11",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",
     "reveal": "0.0.4",

--- a/stores/SlideEditStore.js
+++ b/stores/SlideEditStore.js
@@ -8,6 +8,7 @@ class SlideEditStore extends BaseStore {
         this.title = '';
         this.content = '';
         this.speakernotes = '';
+        this.scaleratio = 1; //default no scale ratio
     }
     updateContent(payload) {
         //console.log('test' + payload + payload.slide.content + ' title: ' +  payload.slide.title + ' id: ' + payload.slide.id);
@@ -50,6 +51,7 @@ class SlideEditStore extends BaseStore {
             title: this.title,
             content: this.content,
             speakernotes: this.speakernotes,
+            scaleratio: this.scaleratio,
         };
     }
     dehydrate() {
@@ -60,6 +62,7 @@ class SlideEditStore extends BaseStore {
         this.title = state.title;
         this.content = state.content;
         this.speakernotes = state.speakernotes;
+        this.scaleratio = state.scaleratio;
     }
 }
 


### PR DESCRIPTION
Only in slide-content editor (ugly hacks for now (testing/QA) cover
your eyes / burn it with fire)
- calculate scale ratio based on edit react component and size of pptx
slide content
- use scale ratio to re-initiate mouse-calculation of resize & drag in
simple-draggable. used clone-node to remove event listeners.

Tested in firefox and chrome with deck 344 -
http://localhost:3000/deck/344-2/slide/1394-1/1394-1:8/edit
I assume(!) this works also in newer decks/imports