### PR TITLE
Swik 611 fix signup language atribute

### DIFF
--- a/components/User/UserRegistration/UserRegistration.js
+++ b/components/User/UserRegistration/UserRegistration.js
@@ -152,7 +152,9 @@ class UserRegistration extends React.Component {
     handleSignUp(e) {
         e.preventDefault();
         let language = navigator.browserLanguage ? navigator.browserLanguage : navigator.language;
-        // let username = $('#firstname').val().charAt(0).toLowerCase() + $('#lastname').val().toLowerCase();
+        if (language.length === 2) {
+            language += '-' + language.toUpperCase();
+        }// let username = $('#firstname').val().charAt(0).toLowerCase() + $('#lastname').val().toLowerCase();
 
         this.context.executeAction(userSignUp, {
             firstname: this.refs.firstname.value,

--- a/components/User/UserRegistration/UserRegistration.js
+++ b/components/User/UserRegistration/UserRegistration.js
@@ -154,7 +154,8 @@ class UserRegistration extends React.Component {
         let language = navigator.browserLanguage ? navigator.browserLanguage : navigator.language;
         if (language.length === 2) {
             language += '-' + language.toUpperCase();
-        }// let username = $('#firstname').val().charAt(0).toLowerCase() + $('#lastname').val().toLowerCase();
+        }
+        // let username = $('#firstname').val().charAt(0).toLowerCase() + $('#lastname').val().toLowerCase();
 
         this.context.executeAction(userSignUp, {
             firstname: this.refs.firstname.value,


### PR DESCRIPTION
User Registration component gets the user language from the browser. There are cases when browser gives two-character code (e.g. 'de') instead of five-character, which is needed for the user-service.
This is a temporary fix for this problem.