### PR TITLE
SWIK-684 Make CSS consistent for presentation mode and display slightly better

### DIFF
--- a/components/Deck/Presentation/Presentation.js
+++ b/components/Deck/Presentation/Presentation.js
@@ -11,7 +11,6 @@ let playerCss = {
     height: '100%',
     position: 'absolute',
     top: '0',
-    fontSize: '100%'
 };
 
 let clearStyle = {


### PR DESCRIPTION
Very minor change.  Should make the display consistent between the Presentation mode and View and Edit modes.

See also the change in the SWIK-684 branch in the slidewiki/reveal.js library.  That will adjust the default size of the `white.css` file to 28px making the `<h1>` element 70px (2.5em)