### PR TITLE
SWIK-683 Download and PrintButton do the same:download the entire dec…

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -27,7 +27,7 @@ class ContentActionsFooter extends React.Component {
         let presLocation = '/Presentation/' + this.props.ContentStore.selector.id + '/';
         if(this.props.ContentStore.selector.stype === 'slide'){
             // presLocation += this.props.ContentStore.selector.sid + '/';
-            presLocation += '#/slide-' + this.props.ContentStore.selector.sid
+            presLocation += '#/slide-' + this.props.ContentStore.selector.sid;
         }
         return presLocation;
     }
@@ -48,16 +48,24 @@ class ContentActionsFooter extends React.Component {
         }
     }*/
     getPDFHref(){
-      let pdfHref = Microservices.pdf.uri + '/exportPDF/' + this.props.ContentStore.selector.id;
-      console.log('pdfHref: ' + pdfHref);
-      return pdfHref;
+        let pdfHref;
+        if(this.props.ContentStore.selector.stype === 'slide'){
+            let splittedId =  this.props.ContentStore.selector.id.split('-'); //separates deckId and slideId
+            pdfHref = Microservices.pdf.uri + '/exportPDF/' + splittedId[0];
+
+        } else{
+            pdfHref = Microservices.pdf.uri + '/exportPDF/' + this.props.ContentStore.selector.id;
+
+        }
+        return pdfHref;
     }
+
     handleDownloadClick(e){
-      console.log('handleDownloadClick');
-      if(process.env.BROWSER){
-        e.preventDefault();
-        window.open(this.getPDFHref());
-      }
+
+        if(process.env.BROWSER){
+            e.preventDefault();
+            window.open(this.getPDFHref());
+        }
 
     }
 
@@ -77,10 +85,12 @@ class ContentActionsFooter extends React.Component {
                                     <i className="circle play large icon"></i>
                                 </button>
                             </NavLink>
+
+                           <NavLink onClick={this.handleDownloadClick.bind(this)} href={this.getPDFHref()} target="_blank">
                             <button className="ui button">
                                 <i className="print large icon"></i>
                             </button>
-
+                            </NavLink>
                             <NavLink onClick={this.handleDownloadClick.bind(this)} href={this.getPDFHref()} target="_blank">
                                 <button className="ui button">
                                     <i className="download large icon"></i>


### PR DESCRIPTION
As we don't have the pdf Service prepared to receive slides identifiers, we patch the bug by making that download button always gets a pdf with all the slides from a deck. Also, we do the same action for print button.
Now, both button call the pdfServce by:


`http://pdfservice.experimental.slidewiki.org/exportPDF/{deckId}`

It is possible to check it at: http://svalero.dsic.upv.es:3000/deck/8