### PR TITLE
SWIK-683-fix: removed the revision number from deck id to call pdfser…

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -48,15 +48,11 @@ class ContentActionsFooter extends React.Component {
         }
     }*/
     getPDFHref(){
-        let pdfHref;
-        if(this.props.ContentStore.selector.stype === 'slide'){
-            let splittedId =  this.props.ContentStore.selector.id.split('-'); //separates deckId and slideId
-            pdfHref = Microservices.pdf.uri + '/exportPDF/' + splittedId[0];
 
-        } else{
-            pdfHref = Microservices.pdf.uri + '/exportPDF/' + this.props.ContentStore.selector.id;
+        let splittedId =  this.props.ContentStore.selector.id.split('-'); //separates deckId and revision
 
-        }
+        let pdfHref = Microservices.pdf.uri + '/exportPDF/' + splittedId[0];
+
         return pdfHref;
     }
 


### PR DESCRIPTION
As we don't have the pdf Service prepared to receive slides identifiers, we patch the bug by making that download button always gets a pdf with all the slides from a deck. Also, we do the same action for print button.

Call made: 
http://pdfservice.experimental.slidewiki.org/exportPDF/{decknumber}

where: deckid=decknumer+'-'+deckrevision
For example: 8-2 -->ttp://pdfservice.experimental.slidewiki.org/exportPDF/8