### PR TITLE
SWIK-731 now using PUT instead of POST against /resetPassword

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -134,7 +134,7 @@ export default {
     // other methods
     update: (req, resource, params, body, config, callback) => {
         if (resource === 'user.resetPassword') {
-            rp.post({
+            rp.put({
                 uri: Microservices.user.uri + '/resetPassword',
                 body: JSON.stringify({
                     email: params.email,


### PR DESCRIPTION
Error description: When trying to reset a users password a message appears saying that the users mail address was not found in the database, even though the user account is existing.

This was caused because in services/user.js the call against the userservice's /passwordReset was implemented as a POST.

Fix: changing post to put.  