### PR TITLE
SWIK-453 Converted to client-side password hashing

### DIFF
--- a/components/Login/LoginModal.js
+++ b/components/Login/LoginModal.js
@@ -6,6 +6,7 @@ import userSignOut from '../../actions/user/userSignOut';
 import UserProfileStore from '../../stores/UserProfileStore';
 import HeaderDropdown from './HeaderDropdown.js';
 import ReactDOM from 'react-dom';
+import {hashPassword} from '../../configs/general';
 let classNames = require('classnames');
 
 const headerStyle = {
@@ -44,7 +45,7 @@ class LoginModal extends React.Component {
         } else {
             this.context.executeAction(userSignIn, {
                 email: this.refs.email1.value,
-                password: this.refs.password1.value
+                password: hashPassword(this.refs.password1.value)
             });
 
             this.refs.email1.value = '';

--- a/components/User/UserProfile/ChangePassword.js
+++ b/components/User/UserProfile/ChangePassword.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import changePassword from '../../../actions/user/userprofile/changePassword';
+import {hashPassword} from '../../../configs/general';
 
 class ChangePassword extends React.Component {
     componentDidMount() {
@@ -28,8 +29,8 @@ class ChangePassword extends React.Component {
     handleChangePassword(e) {
         e.preventDefault();
         let payload = {
-            oldpw: this.refs.oldPassword.value,
-            newpw: this.refs.newPassword.value
+            oldpw: hashPassword(this.refs.oldPassword.value),
+            newpw: hashPassword(this.refs.newPassword.value)
         };
         this.refs.oldPassword.value = '';
         this.refs.newPassword.value = '';

--- a/components/User/UserProfile/UserSettings.js
+++ b/components/User/UserProfile/UserSettings.js
@@ -22,7 +22,7 @@ class UserSettings extends React.Component {
                 allowEscapeKey: false,
                 showConfirmButton: false
             })
-            .then(() => {});
+            .then(() => {}).catch(swal.noop);
         if (this.props.dimmer.userdeleted === true)
             swal({
                 type: 'success',
@@ -34,7 +34,7 @@ class UserSettings extends React.Component {
                 allowEscapeKey: false,
                 showConfirmButton: false
             })
-            .then(() => {});
+            .then(() => {}).catch(swal.noop);
         if (this.props.dimmer.failure === true)
             swal({
                 title: 'Error',
@@ -46,7 +46,7 @@ class UserSettings extends React.Component {
                 confirmButtonClass: 'negative ui button',
                 buttonsStyling: false
             })
-            .then(() => {});
+            .then(() => {}).catch(swal.noop);
     }
 
     enableAccordion(status) {

--- a/components/User/UserRegistration/UserRegistration.js
+++ b/components/User/UserRegistration/UserRegistration.js
@@ -10,6 +10,7 @@ import checkEmail from '../../../actions/user/registration/checkEmail';
 import checkUsername from '../../../actions/user/registration/checkUsername';
 import UserRegistrationStore from '../../../stores/UserRegistrationStore';
 import ReCAPTCHA from 'react-google-recaptcha';
+import {hashPassword} from '../../../configs/general';
 
 class UserRegistration extends React.Component {
     componentDidMount() {
@@ -180,7 +181,7 @@ class UserRegistration extends React.Component {
             username: this.refs.username.value,
             language: language,
             email: this.refs.email.value,
-            password: this.refs.password.value,
+            password: hashPassword(this.refs.password.value),
             grecaptcharesponse: this.state.grecaptcharesponse
         });
         return false;

--- a/configs/general.js
+++ b/configs/general.js
@@ -1,10 +1,14 @@
+import sha512 from 'js-sha512';
+
 export default {
     //full page title
     fullTitle: ['SlideWiki -- Authoring platform for OpenCourseWare'],
     //short page title
     shortTitle: ['SlideWiki'],
-    //salt for password hashing
-    hashSalt: ['6cee6c6a420e0573d1a4ad8ecb44f2113d010a0c3aadd3c1251b9aa1406ba6a3'],
+    hashPassword: function(password) {
+        let hashSalt = '6cee6c6a420e0573d1a4ad8ecb44f2113d010a0c3aadd3c1251b9aa1406ba6a3'; //salt for password hashing
+        return sha512.sha512(password + hashSalt);
+    },
     //API Key
     resetPasswordAPIKey: '2cbc621f86e97189239ee8c4c80b10b3a935b8a9f5db3def7b6a3ae7c4b75cb5'
 };

--- a/services/user.js
+++ b/services/user.js
@@ -23,7 +23,6 @@ export default {
 
         } else if (resource === 'user.signin') {
             const hashedPassword = args.password;
-            console.log(hashedPassword);
             rp.post({
                 uri: Microservices.user.uri + '/login',
                 body: JSON.stringify({
@@ -76,7 +75,6 @@ export default {
         let args = params.params ? params.params : params;
         if (resource === 'user.registration') {
             const hashedPassword = args.password;
-            console.log(hashedPassword);
             const PRIVATE_KEY = '6LdNLyYTAAAAAFMC0J_zuVI1b9lXWZjPH6WLe-vJ';
             rp.post({
                 uri: 'https://www.google.com/recaptcha/api/siteverify',

--- a/services/user.js
+++ b/services/user.js
@@ -1,7 +1,6 @@
 import { Microservices } from '../configs/microservices';
-import { hashSalt, resetPasswordAPIKey } from '../configs/general';
+import { resetPasswordAPIKey } from '../configs/general';
 import rp from 'request-promise';
-import sha512 from 'js-sha512';
 
 export default {
     name: 'user',
@@ -23,7 +22,8 @@ export default {
             });
 
         } else if (resource === 'user.signin') {
-            const hashedPassword = sha512.sha512(args.password + hashSalt);
+            const hashedPassword = args.password;
+            console.log(hashedPassword);
             rp.post({
                 uri: Microservices.user.uri + '/login',
                 body: JSON.stringify({
@@ -75,7 +75,8 @@ export default {
     create: (req, resource, params, body, config, callback) => {
         let args = params.params ? params.params : params;
         if (resource === 'user.registration') {
-            const hashedPassword = sha512.sha512(args.password + hashSalt);
+            const hashedPassword = args.password;
+            console.log(hashedPassword);
             const PRIVATE_KEY = '6LdNLyYTAAAAAFMC0J_zuVI1b9lXWZjPH6WLe-vJ';
             rp.post({
                 uri: 'https://www.google.com/recaptcha/api/siteverify',

--- a/services/userProfile.js
+++ b/services/userProfile.js
@@ -1,7 +1,5 @@
-import sha512 from 'js-sha512';
 import rp from 'request-promise';
 import { isEmpty } from '../common.js';
-import { hashSalt } from '../configs/general';
 import { Microservices } from '../configs/microservices';
 
 export default {
@@ -20,8 +18,8 @@ export default {
     update: (req, resource, params, body, config, callback) => {
         if (resource === 'userProfile.updatePassword') {
             let tosend = {
-                oldPassword: sha512.sha512(params.oldpw + hashSalt),
-                newPassword: sha512.sha512(params.newpw + hashSalt)
+                oldPassword: params.oldpw,
+                newPassword: params.newpw
             };
             rp({
                 method: 'PUT',


### PR DESCRIPTION
I've exchanged the in-service password hashing with one that is in most cases executed client-side. This is a huge security improvement, but doesn't tackle the isomorphic approach of fluxible. Thus, a plain text password might be sent to the server-side rendering in case someone uses the isomorphic characteristic.

How to test: Can you still login with your (existing) credentials? Can you register a new user and login? Can you alter your password and still login?