### PR TITLE
Swik 469 adding sources of slides

### DIFF
--- a/actions/datasource/cancelEditDataSource.js
+++ b/actions/datasource/cancelEditDataSource.js
@@ -1,4 +1,4 @@
 export default function cancelEditDataSource(context, payload, done) {
-    context.dispatch('CANCEL_EDIT_DATASOURCE', payload);
+    context.dispatch('CANCEL_EDIT_DATASOURCE');
     done();
 }

--- a/actions/datasource/newDataSource.js
+++ b/actions/datasource/newDataSource.js
@@ -1,4 +1,4 @@
 export default function newDataSource(context, payload, done) {
 
-    context.dispatch('NEW_DATASOURCE', payload);
+    context.dispatch('NEW_DATASOURCE');
 }

--- a/actions/datasource/showMoreDataSources.js
+++ b/actions/datasource/showMoreDataSources.js
@@ -1,0 +1,4 @@
+export default function showMoreDataSources(context, payload, done) {
+
+    context.dispatch('SHOW_ALL_DATASOURCES');
+}

--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
@@ -55,9 +55,9 @@ class AddComment extends React.Component {
               </div>
 
               <button tabIndex="0" type="submit" className="ui blue labeled submit icon button" >
-                  <i className="icon edit"></i> Submit
+                  <i className="icon check"></i> Submit
               </button>
-              <button tabIndex="0" type="button" className="ui blue labeled close icon button" onClick={this.handleInvertCommentBox.bind(this)}>
+              <button tabIndex="0" type="button" className="ui secondary labeled close icon button" onClick={this.handleInvertCommentBox.bind(this)}>
                   <i className="icon close"></i> Cancel
               </button>
               <div className="ui error message"/>

--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/ContentDiscussionPanel.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/ContentDiscussionPanel.js
@@ -25,7 +25,7 @@ class ContentDiscussionPanel extends React.Component {
             (<AddComment/>)
             :
             (<button tabIndex="0" className="ui blue labeled icon button" onClick={this.handleInvertCommentBox.bind(this)}>
-                <i className="icon edit"></i> Add comment
+                <i className="icon plus"></i> Add comment
             </button>);
 
         return (

--- a/components/Deck/ContentModulesPanel/DataSourcePanel/DataSourcePanel.js
+++ b/components/Deck/ContentModulesPanel/DataSourcePanel/DataSourcePanel.js
@@ -6,15 +6,23 @@ import DataSourceList from './DataSourceList';
 import EditDataSource from './EditDataSource';
 import ShadowScrollbars from './Scrollbars/ShadowScrollbars';
 import newDataSource from '../../../../actions/datasource/newDataSource';
+import showMoreDataSources from '../../../../actions/datasource/showMoreDataSources';
 
 class DataSourcePanel extends React.Component {
     handleNewDataSource() {
-        this.context.executeAction(newDataSource, {
-        });
+        this.context.executeAction(newDataSource);
+    }
+
+    handleShowMore(e) {
+        e.preventDefault();
+        this.context.executeAction(showMoreDataSources);
     }
 
     render() {
         const dataSources = this.props.DataSourceStore.dataSources;
+        const arrayOfDataSourcesIsLarge = dataSources.length > 10;
+        const showAllDataSources = this.props.DataSourceStore.showAllDataSources;
+        const displayDataSources = (arrayOfDataSourcesIsLarge && !showAllDataSources) ? dataSources.slice(0, 9) : dataSources;
         const dataSource = this.props.DataSourceStore.dataSource;
         const selector = this.props.DataSourceStore.selector;
         const userId = this.props.UserProfileStore.userid;
@@ -23,19 +31,22 @@ class DataSourcePanel extends React.Component {
 
         let newDataSourceButton = (editable) ?
             <button tabIndex="0" onClick={this.handleNewDataSource.bind(this)} className="ui blue labeled icon button">
-                <i className="icon edit"></i> Add Data Source
+                <i className="icon plus"></i> Add source
             </button>
             : '';
 
         let sourcesHeader = <h3 className="ui dividing header">Sources</h3>;
 
+        let showMoreLink = (!showAllDataSources && arrayOfDataSourcesIsLarge) ? <div><br/><a href="#" onClick={this.handleShowMore.bind(this)} >Show more ...</a></div> : '';
         let sourcesList = (dataSources.length === 0)
             ?
             <div>There are currently no sources for this {this.props.DataSourceStore.selector.stype}.</div>
             :
-            <ShadowScrollbars style={{height:300}} >
-                <DataSourceList items={dataSources} editable ={editable} selector={selector}/>
-            </ShadowScrollbars>;
+            <div>
+                <DataSourceList items={displayDataSources} editable ={editable} selector={selector}/>
+                {showMoreLink}
+            </div>
+            ;
 
         let editForm = <EditDataSource dataSource={dataSource}/>;
 

--- a/components/Deck/ContentModulesPanel/DataSourcePanel/EditDataSource.js
+++ b/components/Deck/ContentModulesPanel/DataSourcePanel/EditDataSource.js
@@ -63,15 +63,15 @@ class EditDataSource extends React.Component {
     }
 
     render() {
-        let header = 'Edit Data Source';
+        let header = 'Edit source';
         let dataSource = this.props.dataSource;
         let deleteButton = (
             <button tabIndex="0" type="button" onClick={this.handleDeleteClick.bind(this)} className="ui red labeled icon button">
-                <i className="icon close"></i> Delete
+                <i className="icon minus circle"></i> Delete
             </button>
         );
         if (dataSource === null) {
-            header = 'Add Data Source';
+            header = 'Add source';
             dataSource = {title: '', url: '', comment: ''};
             deleteButton = '';
         }
@@ -114,9 +114,9 @@ class EditDataSource extends React.Component {
 
                     <div className="ui hidden divider"></div>
                     <button tabIndex="0" type="submit" className="ui blue labeled submit icon button" >
-                        <i className="icon edit"></i> Submit
+                        <i className="icon check"></i> Submit
                     </button>
-                    <button tabIndex="0" type="button" onClick={this.handleCancelClick.bind(this)} className="ui blue labeled icon button">
+                    <button tabIndex="0" type="button" onClick={this.handleCancelClick.bind(this)} className="ui secondary labeled icon button">
                         <i className="icon close"></i> Cancel
                     </button>
                     {deleteButton}

--- a/components/Deck/ContentModulesPanel/DataSourcePanel/Scrollbars/ShadowScrollbars.js
+++ b/components/Deck/ContentModulesPanel/DataSourcePanel/Scrollbars/ShadowScrollbars.js
@@ -1,3 +1,5 @@
+// CURRENTLY NOT USED
+
 import React, { PropTypes } from 'react';
 import { Scrollbars } from 'react-custom-scrollbars';
 

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -7,6 +7,7 @@ import React from 'react';
 import {NavLink} from 'fluxible-router';
 import {connectToStores} from 'fluxible-addons-react';
 import SlideEditStore from '../../../../../stores/SlideEditStore';
+import DataSourceStore from '../../../../../stores/DataSourceStore';
 import addSlide from '../../../../../actions/slide/addSlide';
 import saveSlide from '../../../../../actions/slide/saveSlide';
 import loadSlideAll from '../../../../../actions/slide/loadSlideAll';
@@ -83,8 +84,9 @@ class SlideContentEditor extends React.Component {
             //TODO GET subdeck from spath in currentSelector e.g. = Object {id: "56", sid: "691", stype: "slide", spath: "68:3;685:1;691:2"} = 56 is deck, 68 is subdeck
             //TEST - create slide (before can be saved (=updated))
             //console.log(speakernotes);
+            let dataSources = (this.props.DataSourceStore.dataSources !== undefined) ? this.props.DataSourceStore.dataSources : [];
             this.context.executeAction(saveSlide,
-              {id: currentSelector.sid, deckID: deckID, title: title, content: content, speakernotes: speakernotes, selector: currentSelector});
+              {id: currentSelector.sid, deckID: deckID, title: title, content: content, speakernotes: speakernotes, dataSources: dataSources, selector: currentSelector});
             //console.log('saving slide');
             this.resize();
         }
@@ -391,10 +393,11 @@ SlideContentEditor.contextTypes = {
     executeAction: React.PropTypes.func.isRequired
 };
 
-SlideContentEditor = connectToStores(SlideContentEditor, [SlideEditStore, UserProfileStore], (context, props) => {
+SlideContentEditor = connectToStores(SlideContentEditor, [SlideEditStore, UserProfileStore, DataSourceStore], (context, props) => {
     return {
         SlideEditStore: context.getStore(SlideEditStore).getState(),
-        UserProfileStore: context.getStore(UserProfileStore).getState()
+        UserProfileStore: context.getStore(UserProfileStore).getState(),
+        DataSourceStore: context.getStore(DataSourceStore).getState()
     };
 });
 export default SlideContentEditor;

--- a/services/datasource.js
+++ b/services/datasource.js
@@ -95,7 +95,7 @@ function getDataSourcesFromDeckOrSlide(id, deckOrSlide) {
     if (deckOrSlide.revisions !== undefined && deckOrSlide.revisions.length > 0 && deckOrSlide.revisions[0] !== null) {
         let contentRevision = (contentRevisionId !== undefined) ? deckOrSlide.revisions.find((revision) => String(revision.id) === String(contentRevisionId)) : undefined;
         if (contentRevision !== undefined) {
-            dataSources = (contentRevision.dataSources !== undefined) ? contentRevision.dataSources : [];
+            dataSources = (contentRevision.dataSources !== undefined && contentRevision.dataSources !== null) ? contentRevision.dataSources : [];
             revisionOwner = contentRevision.user;
         }
     }

--- a/services/slide.js
+++ b/services/slide.js
@@ -135,7 +135,7 @@ export default {
                     },
                     position: content_id,
                     language: 'EN',
-                    position: content_id,
+                    dataSources: args.dataSources,
                     license: 'CC BY-SA'
                 })
             }).then((res) => {

--- a/stores/DataSourceStore.js
+++ b/stores/DataSourceStore.js
@@ -4,6 +4,7 @@ class DataSourceStore extends BaseStore {
     constructor(dispatcher) {
         super(dispatcher);
         this.dataSources = [];
+        this.showAllDataSources = false;
         this.dataSource = undefined;
         this.selectedIndex = -1;
         this.contentOwner = 0;
@@ -28,18 +29,23 @@ class DataSourceStore extends BaseStore {
         this.selectedIndex = -1;
         this.emitChange();
     }
-    newDataSource(payload) {
+    newDataSource() {
         this.dataSource = null;
         this.emitChange();
     }
-    cancelEditDataSource(payload) {
+    cancelEditDataSource() {
         this.dataSource = undefined;
         this.selectedIndex = -1;
+        this.emitChange();
+    }
+    handleShowAllDataSources() {
+        this.showAllDataSources = true;
         this.emitChange();
     }
     getState() {
         return {
             dataSources: this.dataSources,
+            showAllDataSources: this.showAllDataSources,
             dataSource: this.dataSource,
             selectedIndex: this.selectedIndex,
             contentOwner: this.contentOwner,
@@ -51,6 +57,7 @@ class DataSourceStore extends BaseStore {
     }
     rehydrate(state) {
         this.dataSources = state.dataSources;
+        this.showAllDataSources = state.showAllDataSources;
         this.dataSource = state.dataSource;
         this.selectedIndex = state.selectedIndex;
         this.contentOwner = state.contentOwner;
@@ -63,6 +70,7 @@ DataSourceStore.handlers = {
     'LOAD_DATASOURCES_SUCCESS': 'loadDataSources',
     'LOAD_DATASOURCE': 'loadDataSource',
     'NEW_DATASOURCE': 'newDataSource',
+    'SHOW_ALL_DATASOURCES': 'handleShowAllDataSources',
     'UPDATE_DATASOURCES_SUCCESS': 'updateDataSources',
     'CANCEL_EDIT_DATASOURCE': 'cancelEditDataSource'
 };


### PR DESCRIPTION
-Changed some button icons and labels.
-Added 'show more' link to display all data sources (initially, only first 10 data sources are displayed).
-When saving the slide after editing, data sources are taken from the DataSourceStore and added to the payload of the saveSlide call. Thus, new slide revision gets data sources copied from the previous revision. Latest changes in PR [#44](https://github.com/slidewiki/deck-service/pull/44) are needed in the deck-service.