### PR TITLE
SWIK-762

### DIFF
--- a/actions/decktree/deleteTreeNodeWithRevisionCheck.js
+++ b/actions/decktree/deleteTreeNodeWithRevisionCheck.js
@@ -36,7 +36,22 @@ export default function deleteTreeNodeWithRevisionCheck(context, payload, done) 
                         done(reason);
                     });
                 } else {
-                    context.executeAction(deleteTreeNode, payload, done);
+                    swal({
+                        title: 'Confirmation',
+                        text: 'Do you want to delete this slide?',
+                        type: 'question',
+                        showCloseButton: true,
+                        showCancelButton: true,
+                        confirmButtonText: 'Yes',
+                        confirmButtonClass: 'ui olive button',
+                        cancelButtonText: 'No',
+                        cancelButtonClass: 'ui red button',
+                        buttonsStyling: false
+                    }).then((accepted) => {
+                        context.executeAction(deleteTreeNode, payload, done);
+                    }, (reason) => {
+                        done(reason);
+                    });
                 }
             }
         });


### PR DESCRIPTION
Added a sweet alert to receive the confirmation from user before deleting an slide. 
Code added to deleteTreeNodeWithRevisionCheck

Related with https://slidewiki.atlassian.net/browse/SWIK-762

After the user press the delete button, it should appear an alert message to get the final confirmation from user. In case the change requieres the creation of a new revision of the deck,  the user will ask previously showing only a confirmation about it will create a new revision of the deck...nothing about the deleting process. I take this decision in order not to chain two alert messages