### PR TITLE
SWIK-813 remove empty absolute elements in slide content

### DIFF
--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -217,6 +217,11 @@ class SlideContentEditor extends React.Component {
               , onlyY: false
               , ratio: this.scaleratio
             });
+            SimpleDraggable(".pptx2html > [style*='absolute'] > [style*='absolute']", {
+                onlyX: false
+              , onlyY: false
+              , ratio: this.scaleratio
+            });
             if(document.domain != "localhost")
             {
                 document.domain = 'slidewiki.org';
@@ -281,7 +286,11 @@ class SlideContentEditor extends React.Component {
           , onlyY: false
           , ratio: this.scaleratio
         });
-
+        SimpleDraggable(".pptx2html > [style*='absolute'] > [style*='absolute']", {
+            onlyX: false
+          , onlyY: false
+          , ratio: this.scaleratio
+        });
         //set height of content panel to at least size of pptx2html + (100 pixels * scaleratio).
         this.refs.slideEditPanel.style.height = ((pptxheight + 5 + 20) * this.scaleratio) + 'px';
         this.refs.inlineContent.style.height = ((pptxheight + 0 + 20) * this.scaleratio) + 'px';

--- a/custom_modules/simple-draggable/lib/index.js
+++ b/custom_modules/simple-draggable/lib/index.js
@@ -51,6 +51,8 @@
                 var new_element = cEl.cloneNode(true);
                 cEl.parentNode.replaceChild(new_element, cEl);
                 var cEl = new_element;
+                if(cEl.style.width != '0px' && cEl.style.width != undefined && cEl.style.height != '0px' && cEl.style.height != undefined)
+                {
 
                 // create _simpleDraggable object for this dom element
                 // KLAAS -> added resize
@@ -81,6 +83,7 @@
                 //mouseenter / mouseleave
                 cEl.addEventListener("mouseenter", function (e) {
 
+                    //alert('test');
                     // TODO
                     // document.body.appendChild(cEl);
                     //KLAAS ADAPT
@@ -527,6 +530,7 @@
                     $('.movetofrontdiv').remove();
                     $('.sendtobackdiv').remove();
                 });
+            }
 
             })(allElms[i])
         }


### PR DESCRIPTION
Related to import of SVG graphics.
Surrounding div with no width and height, outside PPTX canvas, is
created, which causes problems with editing.
Now fixed by detection and by also applying drag and resize function to
children of absolute elements in slide edit content

See e.g.
http://platform.experimental.slidewiki.org/deck/3-1/slide/61-1/61-1:26/e
dit