### PR TITLE
Fix deck tree not updating slide rev number on rename

### DIFF
--- a/actions/decktree/saveTreeNode.js
+++ b/actions/decktree/saveTreeNode.js
@@ -10,7 +10,6 @@ export default function saveTreeNode(context, payload, done) {
             if (err) {
                 context.dispatch('SAVE_TREE_NODE_FAILURE', err);
             } else {
-                context.dispatch('SAVE_TREE_NODE_SUCCESS', payload);
                 let newSid = payload.selector.sid, newPath = payload.selector.spath;
                 if (payload.selector.stype === 'slide') {
                     newSid = res._id + '-' + res.revisions[0].id;
@@ -22,6 +21,7 @@ export default function saveTreeNode(context, payload, done) {
                         newPath = pathArr.join(';');
                     }
                 }
+                context.dispatch('SAVE_TREE_NODE_SUCCESS', {selector: payload.selector, newValue: payload.newValue, newSid: newSid, newPath: newPath});
                 let selector = {
                     id: payload.selector.id,
                     stype: payload.selector.stype,

--- a/stores/DeckTreeStore.js
+++ b/stores/DeckTreeStore.js
@@ -288,6 +288,8 @@ class DeckTreeStore extends BaseStore {
         this.deckTree = this.deckTree.updateIn(selectedNodeIndex,(node) => node.update('editable', (val) => false));
         this.deckTree = this.deckTree.updateIn(selectedNodeIndex,(node) => node.update('onAction', (val) => false));
         this.deckTree = this.deckTree.updateIn(selectedNodeIndex,(node) => node.update('title', (val) => payload.newValue));
+        this.deckTree = this.deckTree.updateIn(selectedNodeIndex,(node) => node.update('id', (val) => payload.newSid));
+        this.deckTree = this.deckTree.updateIn(selectedNodeIndex,(node) => node.update('path', (val) => payload.newPath));
         this.emitChange();
     }
     //updates the nodes in the same level of selector which come after the selected node


### PR DESCRIPTION
This PR fixes an issue with the deck tree not being updated with the new rev number after a slide rename.
It created a problem with reordering after a rename, as the old revision with the old title was ultimately moved.