### PR TITLE
Changed Save / Save As / Cancel buttons to <button> 

### DIFF
--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -154,8 +154,8 @@ class DeckPropertiesEditor extends React.Component {
         </select>;
 
         let saveDeckButton = isUserEditor ?
-        <div className='ui primary button' role="button" aria-describedby="saveDeck" tabIndex="0"
-             onClick={this.handleSave.bind(this, false)}>Save</div> : '';
+        <button className='ui primary button'
+             onClick={this.handleSave.bind(this, false)}>Save</button> : '';
 
         return (
         <div className="ui container">
@@ -196,15 +196,14 @@ class DeckPropertiesEditor extends React.Component {
                             </div>
                         </div>
                         {saveDeckButton}
-                        <div className='ui primary button' role="button" aria-describedby="saveNewDeckRevision"
-                             tabIndex="0"
+                        <button className='ui primary button'                     
                              onClick={this.handleSave.bind(this, true)}>
                             Save as new revision
-                        </div>
-                        <div className="ui secondary button" role="button" aria-describedby="cancel" tabIndex="0"
+                        </button>
+                        <button className="ui secondary button"
                              onClick={this.handleCancel.bind(this)}>
                             Cancel
-                        </div>
+                        </button>
                     </form>
                 </div>
 


### PR DESCRIPTION
Makes these buttons activate on Enter/Spacebar when they have focus. However, when testing on my localhost, I was now not directed to the View tab after they are activated. Please can someone test further and see if they can replicate this? The keyboard activation is more important than the redirect to the view tab at the moment.