### PR TITLE
SWIK-787 auto hide decktree

### DIFF
--- a/actions/slide/loadSlideEdit.js
+++ b/actions/slide/loadSlideEdit.js
@@ -1,6 +1,7 @@
 import {shortTitle} from '../../configs/general';
 import slideIdTypeError from '../error/slideIdTypeError';
 import { AllowedPattern } from '../error/util/allowedPattern';
+import expandContentPanel from '../deckpagelayout/expandContentPanel';
 
 export default function loadSlideEdit(context, payload, done) {
     if (!(AllowedPattern.SLIDE_ID.test(payload.params.sid) || payload.params.sid === undefined)) {
@@ -12,7 +13,10 @@ export default function loadSlideEdit(context, payload, done) {
         if (err) {
             context.dispatch('LOAD_SLIDE_EDIT_FAILURE', err);
         } else {
-            context.dispatch('LOAD_SLIDE_EDIT_SUCCESS', res);
+            //expand edit view collapsing TreeNode. Then dispatch LOAD_SLIDE_EDIT_SUCCESS
+            context.executeAction(expandContentPanel,{}, () => {
+                context.dispatch('LOAD_SLIDE_EDIT_SUCCESS', res);
+            });
 
             //TODO: do not allow editing title when on the edit slide mode
             //context.dispatch('UNDO_RENAME_TREE_NODE_SUCCESS', payload.params);

--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ import AddDeckStore from './stores/AddDeckStore';
 import ResetPasswordStore from './stores/ResetPasswordStore';
 import RevisioningStore from './stores/RevisioningStore';
 import DeckListStore from './stores/DeckListStore';
+import ContentActionsFooterStore from './stores/ContentActionsFooterStore';
 
 // create new fluxible instance & register all stores
 const app = new Fluxible({
@@ -70,7 +71,8 @@ const app = new Fluxible({
         AddDeckStore,
         ResetPasswordStore,
         RevisioningStore,
-        DeckListStore
+        DeckListStore,
+        ContentActionsFooterStore
     ]
 });
 

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -6,12 +6,13 @@ import SlideControl from '../SlideModes/SlideControl';
 import expandContentPanel from '../../../../actions/deckpagelayout/expandContentPanel';
 import restoreDeckPageLayout from '../../../../actions/deckpagelayout/restoreDeckPageLayout';
 import {Microservices} from '../../../../configs/microservices';
-
+import ContentActionsFooterStore from '../../../../stores/ContentActionsFooterStore.js';
 
 class ContentActionsFooter extends React.Component {
     constructor(props) {
         super(props);
-        this.state={expanded: 0};
+        //this.state={expanded: 0};
+        this.state = this.props.ContentActionsFooterStore.state; //expanded: 0
     }
     handleExpandClick(){
         this.context.executeAction(expandContentPanel, {});
@@ -121,4 +122,10 @@ class ContentActionsFooter extends React.Component {
 ContentActionsFooter.contextTypes = {
     executeAction: React.PropTypes.func.isRequired
 };
+
+ContentActionsFooter = connectToStores(ContentActionsFooter, [ContentActionsFooterStore], (context, props) => {
+    return {
+        ContentActionsFooterStore: context.getStore(ContentActionsFooterStore).getState()
+    };
+});
 export default ContentActionsFooter;

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideEditPanel.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideEditPanel.js
@@ -1,17 +1,20 @@
 import React from 'react';
-import {NavLink, navigateAction} from 'fluxible-router';
 import {connectToStores} from 'fluxible-addons-react';
-import ContentUtil from '../../util/ContentUtil';
 import SlideEditStore from '../../../../../stores/SlideEditStore';
 import RevisioningStore from '../../../../../stores/RevisioningStore';
 import UserProfileStore from '../../../../../stores/UserProfileStore';
-import needsNewRevisionCheck from '../../../../../actions/revisioning/needsNewRevisionCheck';
-import handleRevisionChanges from '../../../../../actions/revisioning/handleRevisionChanges';
 import SlideContentEditor from './SlideContentEditor';
-import Error from '../../../../../components/Error/Error';
-const ReactDOM = require('react-dom');
+import restoreDeckPageLayout from '../../../../../actions/deckpagelayout/restoreDeckPageLayout';
+
+
 
 class SlideEditPanel extends React.Component {
+    componentWillUnmount(){
+        //show deckTree again
+        context.executeAction(restoreDeckPageLayout,{});
+
+    }
+
     render() {
         //------------------we need to check the revisioning conditions
         //handle the notifications --> in process.env.BROWSER

--- a/stores/ContentActionsFooterStore.js
+++ b/stores/ContentActionsFooterStore.js
@@ -1,0 +1,35 @@
+import {BaseStore} from 'fluxible/addons';
+
+class ContentActionsFooterStore extends BaseStore{
+    constructor(dispatcher) {
+        super(dispatcher);
+        this.state={expanded: 0}; //0 collapsed view; 1 expanded view
+    }
+    getState() {
+        return {
+            state: this.state
+        };
+    }
+    dehydrate() {
+        return this.getState();
+    }
+    rehydrate(state) {
+        this.state = state.state;
+    }
+    setCollapsed(){
+        this.state.expanded = 0;
+    }
+
+    setExpanded(){
+        this.state.expanded = 1;
+    }
+
+
+}
+
+ContentActionsFooterStore.storeName = 'ContentActionsFooterStore';
+ContentActionsFooterStore.handlers = {
+    'EXPAND_CONTENET_PANEL' : 'setExpanded',
+    'RESTORE_DECK_PAGE_LAYOUT' : 'setCollapsed'
+};
+export default ContentActionsFooterStore;


### PR DESCRIPTION
When users select the edit tab to edit an slide, it expands the layout and the decktree is hidden. When users exit from editing an slide, clicking in other option, the original layout is restored. Users can restore the layout while they are editing clicking the restore button (at the footer actions bar). 

Changes at code:
* Components modifications:
  * SlideEditPanel.js: 
    - Unused imports removed
    - ComponenWillUmount() added: executes restoreDeckPageLayout action
  * ContentActionFooter.js: it has a button to expand and collapse the page layout. In order to make it consistent with this auto-hidden process, this component has been connected to an store. The store returns the status layout: expanded or not. Depending of this status, the button displayed allows expand or restore the page layout. 
* Actions modifications:
  * LoadSlideEdit.js: executes expandContentPanel before dispatching LOAD_SLIDE_EDIT_SUCCESS
* Stores mofication:
  * ContentActionsFooterStore: it stores if the page layout is expanded (without decktree) or not. It has handles for 'EXPAND_CONTENET_PANEL' and 'RESTORE_DECK_PAGE_LAYOUT'. They are dispatched from actions expandContentPanel and restoreDeckPageLayout. 
