### PR TITLE
Restricting file formats in the input tag.

### DIFF
--- a/components/Import/Import.js
+++ b/components/Import/Import.js
@@ -103,7 +103,7 @@ class Import extends React.Component {
             'button': true,
             'green': true
         });
-
+        let acceptedFormats = '.key, .odp, .pps, .ppsx, .ppt, .pptm, .pptx,  ';
         outputDIV =   <div className="ui small modal" ref="import">
                           <div className="header">
                               <h2>Upload your presentation</h2>
@@ -112,7 +112,7 @@ class Import extends React.Component {
                               <p>Select your presentation file and upload it to SlideWiki.</p>
                               <p>Only PowerPoint (.pptx) is supported (Max size: {MAX_FILESIZE_MB}MB).</p>
                               <div className="ui input file focus animated">
-                                    <input ref="selectbutton" accept="application/vnd.openxmlformats-officedocument.presentationml.presentation" type="file" tabIndex="0" onChange={this.handleFileSelect.bind(this)} id="import_file_chooser" ></input>
+                                    <input ref="selectbutton" accept={ acceptedFormats + "application/vnd.openxmlformats-officedocument.presentationml.presentation"} type="file" tabIndex="0" onChange={this.handleFileSelect.bind(this)} id="import_file_chooser" ></input>
                               </div>
                           </div>
                           <div className="actions">


### PR DESCRIPTION
Now the files are filtered also by their extension, so only presentation formats are showed when trying to upload a file in the add deck view.