### PR TITLE
SWIK-633 Fix render issue of language specific characters

### DIFF
--- a/components/Deck/NavigationPanel/Breadcrumb.js
+++ b/components/Deck/NavigationPanel/Breadcrumb.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {NavLink} from 'fluxible-router';
+import cheerio from 'cheerio';
 
 class Breadcrumb extends React.Component {
     render() {
@@ -12,7 +13,7 @@ class Breadcrumb extends React.Component {
                 if(index === (nodes.length - 1)){
                     return (
                         <div key={index} className="section">
-                            {this.props.pathNames[index]}
+                            {cheerio.load(this.props.pathNames[index]).text()}
                         </div>
                     );
                 }else{

--- a/components/Deck/TreePanel/TreeNode.js
+++ b/components/Deck/TreePanel/TreeNode.js
@@ -6,6 +6,7 @@ import TreeUtil from './util/TreeUtil';
 import {DragSource, DropTarget} from 'react-dnd';
 import TreeNodeList from './TreeNodeList';
 import TreeNodeTarget from './TreeNodeTarget';
+import cheerio from 'cheerio';
 
 
 const findAllDescendants = (node) => Immutable.Set.of(node).union(node.get('children') ? node.get('children').flatMap(findAllDescendants) : Immutable.List());
@@ -190,7 +191,7 @@ class TreeNode extends React.Component {
             </div>
         );
         //change the node title style if it is selected
-        let nodeTitle = this.props.item.get('title');
+        const nodeTitle = cheerio.load(this.props.item.get('title')).text();
         let nodeTitleDIV = nodeTitle;
         if (this.props.item.get('selected')) {
             nodeTitleDIV = <strong> {nodeTitle} </strong>;


### PR DESCRIPTION
The DB stores the data in the following manner:
`&#xBF;` for `¿`

Simple data type casting on the client did the trick.

> A test deck could be found in the comment section of the respective ticket