### PR TITLE
SWIK-1061 Exchanged the thumbnail retrievel code to use the new file-service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,3 @@ add the config for your microservices:
 `npm run dev`
 
 check server at `localhost:3000`
-
-
-## Migrate thumbnails ##
-```
-cd /data/files
-find ./ -name thumbnails -type d -exec find {} -name *.png \; > list
-while read in; do cp "$in" /data/files/slideThumbnails/ ; done < list
-cd slideThumbnails
-for i in *.png ; do convert "$i" "${i%.*}.jpeg" ; done
-find . -name "*.png" -type f -delete
-```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ add the config for your microservices:
 `npm run dev`
 
 check server at `localhost:3000`
+
+
+## Migrate thumbnails ##
+```
+cd /data/files
+find ./ -name thumbnails -type d -exec find {} -name *.png \; > list
+while read in; do cp "$in" /data/files/slideThumbnails/ ; done < list
+cd slideThumbnails
+for i in *.png ; do convert "$i" "${i%.*}.jpeg" ; done
+find . -name "*.png" -type f -delete
+```

--- a/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
@@ -56,7 +56,7 @@ class DeckViewPanel extends React.Component {
         const totalSlides = lodash.get(this.props.DeckViewStore.slidesData, 'children.length', undefined);
         const maxSlideThumbnails = 3;
 
-        const thumbnailURL = Microservices.file.uri + '/';
+        const thumbnailURL = Microservices.file.uri;
         const deckURL = '/deck/' + this.props.selector.id;
         const creatorProfileURL = '/user/' + deckCreator;
         const ownerProfileURL = '/user/' + deckOwner;
@@ -119,7 +119,7 @@ class DeckViewPanel extends React.Component {
                                         <a href={deckURL + '/slide/' + slide.id} className="ui medium image"
                                            tabIndex="-1">
                                             <Thumbnail key={index}
-                                                       url={thumbnailURL + slide.user + '/thumbnails/' + slide.id + '.png'}
+                                                       url={thumbnailURL + '/slideThumbnail/' + slide.id + '.png'}
                                                        slideId={slide.id}/>
                                         </a>
                                         <a href={deckURL + '/slide/' + slide.id}

--- a/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
@@ -119,7 +119,7 @@ class DeckViewPanel extends React.Component {
                                         <a href={deckURL + '/slide/' + slide.id} className="ui medium image"
                                            tabIndex="-1">
                                             <Thumbnail key={index}
-                                                       url={thumbnailURL + '/slideThumbnail/' + slide.id + '.png'}
+                                                       url={thumbnailURL + '/slideThumbnail/' + slide.id + '.jpeg'}
                                                        slideId={slide.id}/>
                                         </a>
                                         <a href={deckURL + '/slide/' + slide.id}

--- a/components/User/UserProfile/DeckCard.js
+++ b/components/User/UserProfile/DeckCard.js
@@ -14,12 +14,12 @@ class DeckCard extends React.Component {
 
         let thumbnailURL = Microservices.file.uri + '/slideThumbnail/';
         if (this.props.cardContent.firstSlide)
-            thumbnailURL += this.props.cardContent.firstSlide + '.png';
+            thumbnailURL += this.props.cardContent.firstSlide + '.jpeg';
         else
             thumbnailURL = this.props.cardContent.picture;
         return (
             <div className='card'>
-                <NavLink className="ui medium centered image" href={'/deck/' + this.props.cardContent.deckID}>
+                <NavLink className="ui medium centered spaced image" href={'/deck/' + this.props.cardContent.deckID}>
                     <Thumbnail url={thumbnailURL}
                         slideId={this.props.cardContent.deckID} />
                 </NavLink>

--- a/components/User/UserProfile/DeckCard.js
+++ b/components/User/UserProfile/DeckCard.js
@@ -12,7 +12,7 @@ class DeckCard extends React.Component {
     render() {
         // console.log('DeckCard: cardContent', this.props);
 
-        let thumbnailURL = Microservices.file.uri + '/' + (this.props.userid || 0) + '/thumbnails/';
+        let thumbnailURL = Microservices.file.uri + '/slideThumbnail/';
         if (this.props.cardContent.firstSlide)
             thumbnailURL += this.props.cardContent.firstSlide + '.png';
         else

--- a/configs/microservices.sample.js
+++ b/configs/microservices.sample.js
@@ -59,9 +59,6 @@ export default {
         'search': {
             uri: 'https://searchservice.experimental.slidewiki.org'
         },
-        'image': {
-            uri: 'https://imageservice.experimental.slidewiki.org'
-        },
         'file': {
             uri: 'https://fileservice.experimental.slidewiki.org'
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,5 @@ slidewikiplatform:
     - SERVICE_URL_IMPORT=https://importservice.experimental.slidewiki.org
     - SERVICE_URL_FILE=https://fileservice.experimental.slidewiki.org
     - SERVICE_URL_SEARCH=https://searchservice.experimental.slidewiki.org
-    - SERVICE_URL_IMAGE=https://imageservice.experimental.slidewiki.org
     - SERVICE_VAR_IMPORT_HOST=importservice.experimental.slidewiki.org
 #    - SERVICE_USER_APIKEY=

--- a/microservices.js.template
+++ b/microservices.js.template
@@ -27,9 +27,6 @@ export default {
         'search': {
             uri: '${SERVICE_URL_SEARCH}'
         },
-        'image': {
-            uri: '${SERVICE_URL_IMAGE}'
-        },
         'file': {
             uri: '${SERVICE_URL_FILE}'
         },


### PR DESCRIPTION
I've removed the image-service from the docker-compose and microservices.config file, as the service will be discarded (stopped & removed). I've changed the thumbnail retrievel code to match the new API of the file-service.

I haven't tested the changes yet, as I wait for approval of slidewiki/file-service#2 and https://github.com/slidewiki/deck-service/pull/63 first. I'll comment this PR again as soon as the other PR has been merged.