### PR TITLE
Update fork button for new forking

### DIFF
--- a/actions/decktree/forkDeck.js
+++ b/actions/decktree/forkDeck.js
@@ -21,9 +21,10 @@ export default function forkDeck(context, payload, done) {
                 context.executeAction(serviceUnavailable, payload, done);
                 //context.dispatch('FORK_DECK_FAILURE', err);
             } else {
+                console.log(payload);
                 context.dispatch('FORK_DECK_SUCCESS', res);
-                let newSid = res._id + '-' + res.revisions[0].id;
-                let newURL = '/deck/' + newSid;
+                let newId = res.root_deck;
+                let newURL = '/deck/' + newId;
                 //update the URL
                 context.executeAction(navigateAction, {
                     url: newURL

--- a/components/Deck/TreePanel/TreePanel.js
+++ b/components/Deck/TreePanel/TreePanel.js
@@ -57,8 +57,8 @@ class TreePanel extends React.Component {
 
     handleFork() {
         swal({
-            title: 'New Revision',
-            text: 'We are creating a new revision of the deck...',
+            title: 'New Fork',
+            text: 'We are forking the deck...',
             type: 'success',
             timer: 2000,
             showCloseButton: false,

--- a/services/deck.js
+++ b/services/deck.js
@@ -237,7 +237,7 @@ export default {
                 body: {
                     user: params.userid.toString()
                 }
-            }).then((deck) => callback(false, deck))
+            }).then((res) => callback(false, res))
             .catch((err) => callback(err));
         }
     }


### PR DESCRIPTION
This PR makes the necessary changes in order for the fork button to work with the updated deck-service fork.