### PR TITLE
Swik 1113 fixing page title activities

### DIFF
--- a/actions/activityfeed/loadActivities.js
+++ b/actions/activityfeed/loadActivities.js
@@ -1,4 +1,4 @@
-import { shortTitle } from '../../configs/general';
+// import { shortTitle } from '../../configs/general';
 import deckContentTypeError from '../error/deckContentTypeError';
 import slideIdTypeError  from '../error/slideIdTypeError';
 import serviceUnavailable from '../error/serviceUnavailable';

--- a/actions/activityfeed/loadActivities.js
+++ b/actions/activityfeed/loadActivities.js
@@ -26,10 +26,10 @@ export default function loadActivities(context, payload, done) {
             context.dispatch('LOAD_ACTIVITIES_SUCCESS', res);
             context.dispatch('UPDATE_ACTIVITY_TYPE_SUCCESS', {activityType: 'all'});
         }
-        let pageTitle = shortTitle + ' | Activities | ' + payload.params.stype + ' | ' + payload.params.sid;
-        context.dispatch('UPDATE_PAGE_TITLE', {
-            pageTitle: pageTitle
-        });
+        // let pageTitle = shortTitle + ' | Activities | ' + payload.params.stype + ' | ' + payload.params.sid;
+        // context.dispatch('UPDATE_PAGE_TITLE', {
+        //     pageTitle: pageTitle
+        // });
         done();
     });
 }

--- a/actions/loadContentModules.js
+++ b/actions/loadContentModules.js
@@ -1,5 +1,5 @@
 import async from 'async';
-import { shortTitle } from '../configs/general';
+// import { shortTitle } from '../configs/general';
 // import loadContentDiscussion from './contentdiscussion/loadContentDiscussion';
 import loadDataSources from './datasource/loadDataSources';
 import loadDataSourceCount from './datasource/loadDataSourceCount';

--- a/actions/loadContentModules.js
+++ b/actions/loadContentModules.js
@@ -51,10 +51,10 @@ export default function loadContentModules(context, payload, done) {
             context.executeAction(serviceUnavailable, payload, done);
         }
         context.dispatch('LOAD_CONTENT_MODULES_SUCCESS', {selector: payload.params, moduleType: 'datasource'});
-        let pageTitle = shortTitle + ' | Activities | ' + payload.params.stype + ' | ' + payload.params.sid;
-        context.dispatch('UPDATE_PAGE_TITLE', {
-            pageTitle: pageTitle
-        });
+        // let pageTitle = shortTitle + ' | Activities | ' + payload.params.stype + ' | ' + payload.params.sid;
+        // context.dispatch('UPDATE_PAGE_TITLE', {
+        //     pageTitle: pageTitle
+        // });
         done();
     });
 }

--- a/components/Deck/ContentModulesPanel/ContentModulesPanel.js
+++ b/components/Deck/ContentModulesPanel/ContentModulesPanel.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {connectToStores} from 'fluxible-addons-react';
 import classNames from 'classnames/bind';
 import restoreDeckPageLayout from '../../../actions/deckpagelayout/restoreDeckPageLayout';
-import loadActivities from '../../../actions/activityfeed/loadActivities';
 import loadContentDiscussion from '../../../actions/contentdiscussion/loadContentDiscussion';
 import loadCommentsCount from '../../../actions/contentdiscussion/loadCommentsCount';
 import loadContentHistory from '../../../actions/history/loadContentHistory';

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -275,7 +275,21 @@ export default {
         page: 'activities',
         handler: require('../components/Deck/ActivityFeedPanel/ActivityFeedPanel'),
         action: (context, payload, done) => {
-            context.executeAction(loadActivities, payload, done);
+            async.series([
+                (callback) => {
+                    context.dispatch('UPDATE_PAGE_TITLE', {
+                        pageTitle: shortTitle + ' | Activities'
+                    });
+                    callback();
+                },
+                (callback) => {
+                    context.executeAction(loadActivities, payload, done);
+                }
+            ],
+            (err, result) => {
+                if(err) console.log(err);
+                done();
+            });
         }
     },
     translations: {


### PR DESCRIPTION
Just a couple of small changes to fix the SWIK-1113 bug:
Code for changing page title to 'Activities' is removed from loadActivities and loadContentModules actions, which are called from the loadDeck action, and added to the action for 'activities' page in routes.js.