### PR TITLE
Revert change to prevent scrolling when draggin

### DIFF
--- a/custom_modules/simple-draggable/lib/index.js
+++ b/custom_modules/simple-draggable/lib/index.js
@@ -164,9 +164,9 @@
                         };
 
                         //fix to prevent scrolling
-                        $('.pptx2html').css('overflow', 'hidden');
+                        //$('.pptx2html').css('overflow', 'hidden');
                         //$('.pptx2html').css('height', '100%');
-                        $('body').css('overflow', 'hidden');
+                        ////$('body').css('overflowY', 'hidden');
                         //$('body').css('height', '100%');
 
                         //cEl.style.overflow = 'hidden';
@@ -207,7 +207,7 @@
                         //restore fix to prevent scrolling
                         $('.pptx2html').css('overflow', '');
                         //$('.pptx2html').css('height', '');
-                        $('body').css('overflow', '');
+                        $('body').css('overflowY', '');
                         //$('body').css('height', '');
 
                         //restore z-index - element was moved to front - to prevent conflict with handlers on elements with larger z-index (which then trigger)
@@ -417,9 +417,9 @@
                         };
 
                         //fix to prevent scrolling
-                        $('.pptx2html').css('overflow', 'hidden');
+                        ////$('.pptx2html').css('overflow', 'hidden');
                         //$('.pptx2html').css('height', '100%');
-                        $('body').css('overflow', 'hidden');
+                        //$('body').css('overflowY', 'hidden');
                         //$('body').css('height', '100%');
 
                         //move element to front to prevent conflict with handlers on elements with larger z-index (which then trigger)
@@ -463,7 +463,7 @@
                         //restore fix to prevent scrolling
                         $('.pptx2html').css('overflow', '');
                         //$('.pptx2html').css('height', '');
-                        $('body').css('overflow', '');
+                        $('body').css('overflowY', '');
                         //$('body').css('height', '');
 
                         //restore z-index - element was moved to front - to prevent conflict with handlers on elements with larger z-index (which then trigger)


### PR DESCRIPTION
Earlier fix sets $('body').css('overflow', 'hidden');
But this removes scrollbar, shifting content to right, and this may
make a user miss the button once clicked.