### PR TITLE
SWIK-1096_error_when_there_are_no_recent_decks

### DIFF
--- a/actions/loadRecent.js
+++ b/actions/loadRecent.js
@@ -6,9 +6,15 @@ export default function loadRecent(context, payload, done) {
     context.service.read('deck.recent', payload, {timeout: 20 * 1000}, (err, res) => {
       //  console.log('Executing loadPresentation action');
         if (err) {
-            log.error(context, {filepath: __filename, err: err});
-            context.executeAction(serviceUnavailable, payload, done);
-            //context.dispatch('LOAD_HOME_PAGE_FAILURE', err);
+            if (err.statusCode === 404) {
+                let data = {recent: []};
+                context.dispatch('LOAD_RECENT_SUCCESS', data);
+            }
+            else {
+                log.error(context, {filepath: __filename, err: err});
+                context.executeAction(serviceUnavailable, payload, done);
+                //context.dispatch('LOAD_HOME_PAGE_FAILURE', err);
+            }
         } else {
             context.dispatch('LOAD_RECENT_SUCCESS', res);
         }


### PR DESCRIPTION
Added handling of 404 when loading recent decks