### PR TITLE
SWIK-1213_social_login_facebook_bug

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -51,7 +51,7 @@ export default {
             rp.post({
                 uri: Microservices.user.uri + '/social/login',
                 body: JSON.stringify({
-                    identifier: args.identifier,
+                    identifier: args.identifier.toString(),
                     provider: args.provider,
                     token: args.token,
                     scope: args.scope,
@@ -174,7 +174,7 @@ export default {
             rp.post({
                 uri: Microservices.user.uri + '/social/register',
                 body: JSON.stringify({
-                    identifier: args.identifier,
+                    identifier: args.identifier.toString(),
                     provider: args.provider,
                     token: args.token,
                     scope: args.scope,


### PR DESCRIPTION
Identifier is now always send as string

Just two calls of toString() of a parameter when send to the user-service.