### PR TITLE
Swik 1134 forbid editing old deck revisions

### DIFF
--- a/actions/loadDeck.js
+++ b/actions/loadDeck.js
@@ -18,7 +18,6 @@ import notFoundError from './error/notFoundError';
 import DeckTreeStore from '../stores/DeckTreeStore';
 import loadPermissions from './permissions/loadPermissions';
 import resetPermissions from './permissions/resetPermissions';
-import showNoPermissionsModal from './permissions/showNoPermissionsModal';
 import loadLikes from './activityfeed/loadLikes';
 import PermissionsStore from '../stores/PermissionsStore';
 
@@ -114,10 +113,6 @@ export default function loadDeck(context, payload, done) {
                 let permissions = context.getStore(PermissionsStore).getState().permissions;
                 if (payloadCustom.params.mode === 'edit' && (!permissions.edit || permissions.readOnly)){
                     payloadCustom.params.mode = 'view';
-                    payload.params.user = context.getStore(UserProfileStore).getState().userid;
-                    context.executeAction(showNoPermissionsModal, payloadCustom);
-                } else {
-                    context.dispatch('HIDE_NO_PERMISSIONS_MODAL');
                 }
                 context.executeAction(loadContent, payloadCustom, callback);
             });

--- a/actions/loadDeck.js
+++ b/actions/loadDeck.js
@@ -112,7 +112,7 @@ export default function loadDeck(context, payload, done) {
         (callback) => {
             permissionsPromise.then(() => {
                 let permissions = context.getStore(PermissionsStore).getState().permissions;
-                if (payloadCustom.params.mode === 'edit' && !permissions.edit && !permissions.admin){
+                if (payloadCustom.params.mode === 'edit' && (!permissions.edit || permissions.readOnly)){
                     payloadCustom.params.mode = 'view';
                     payload.params.user = context.getStore(UserProfileStore).getState().userid;
                     context.executeAction(showNoPermissionsModal, payloadCustom);

--- a/actions/permissions/hideNoPermissionsModal.js
+++ b/actions/permissions/hideNoPermissionsModal.js
@@ -1,0 +1,6 @@
+const log = require('../log/clog');
+
+export default function hideNoPermissionsModal(context, payload, done) {
+    context.dispatch('HIDE_NO_PERMISSIONS_MODAL');
+    done();
+}

--- a/actions/permissions/showNoPermissionsModal.js
+++ b/actions/permissions/showNoPermissionsModal.js
@@ -2,13 +2,20 @@ const log = require('../log/clog');
 import serviceUnavailable from '../error/serviceUnavailable';
 
 export default function showNoPermissionsModal(context, payload, done) {
-    context.service.read('deck.forks', payload, {}, (err, res) => {
-        if (err) {
-            log.error(context, {filepath: __filename, err: err});
-            context.executeAction(serviceUnavailable, payload, done);
-        } else {
-            context.dispatch('SHOW_NO_PERMISSIONS_MODAL', {ownedForks: res});
-        }
+    let {selector, user, permissions} = payload;
+    if (!permissions.edit){
+        context.service.read('deck.forks', payload, {}, (err, res) => {
+            if (err) {
+                log.error(context, {filepath: __filename, err: err});
+                context.executeAction(serviceUnavailable, {params:{id: selector.id, user: user}}, done);
+            } else {
+                context.dispatch('SHOW_NO_PERMISSIONS_MODAL', {ownedForks: res});
+            }
+            done();
+        });
+    } else {
+        context.dispatch('SHOW_NO_PERMISSIONS_MODAL');
         done();
-    });
+    }
+
 }

--- a/components/Deck/ContentModulesPanel/ContentHistoryPanel/ContentHistoryItem.js
+++ b/components/Deck/ContentModulesPanel/ContentHistoryPanel/ContentHistoryItem.js
@@ -15,7 +15,7 @@ class ContentHistoryItem extends React.Component {
     render() {
         // console.log('ContentHistoryItem render()', this.props.permissions);
         const revision = this.props.revision;
-        const revertIcon = (this.props.userid !== '' && (this.props.permissions.admin || this.props.permissions.edit)) ? (
+        const revertIcon = (this.props.userid !== '' && this.props.permissions.edit && !this.props.permissions.readOnly) ? (
         <a className="like" onClick={this.handleRevertClick.bind(this)}>
             <i className="undo icon"/>
         </a>

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
@@ -39,19 +39,19 @@ class ContentActionsHeader extends React.Component {
         //config buttons based on the selected item
         const addSlideClass = classNames({
             'item ui small basic left attached button': true,
-            'disabled': !(this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit)
+            'disabled': this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit
         });
         const addDeckClass = classNames({
             'item ui small basic left attached button': true,
-            'disabled': !(this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit)
+            'disabled': this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit
         });
         const duplicateItemClass = classNames({
             'item ui small basic left attached button': true,
-            'disabled': contentDetails.selector.id === contentDetails.selector.sid || contentDetails.selector.stype==='deck' || !(this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit)
+            'disabled': contentDetails.selector.id === contentDetails.selector.sid || contentDetails.selector.stype==='deck' || this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit
         });
         const deleteItemClass = classNames({
             'item ui small basic left attached button': true,
-            'disabled': contentDetails.selector.id === contentDetails.selector.sid || !(this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit)
+            'disabled': contentDetails.selector.id === contentDetails.selector.sid || this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit
         });
         let selectorImm = this.props.DeckTreeStore.selector;
         let selector = {id: selectorImm.get('id'), stype: selectorImm.get('stype'), sid: selectorImm.get('sid'), spath: selectorImm.get('spath')};
@@ -59,7 +59,7 @@ class ContentActionsHeader extends React.Component {
         let buttonStyle = {
             classNames : classNames({
                 'item small attached left':true,
-                'disabled': !(this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit)
+                'disabled': this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit
             }),
             iconSize : 'large',
             attached : 'left'

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
@@ -9,9 +9,12 @@ import addTreeNodeAndNavigate from '../../../../actions/decktree/addTreeNodeAndN
 import deleteTreeNodeAndNavigate from '../../../../actions/decktree/deleteTreeNodeAndNavigate';
 import AttachSubdeck from '../AttachSubdeck/AttachSubdeckModal.js';
 import PermissionsStore from '../../../../stores/PermissionsStore';
+import showNoPermissionsModal from '../../../../actions/permissions/showNoPermissionsModal';
+
 
 
 class ContentActionsHeader extends React.Component {
+
     componentDidUpdate(){
 
     }
@@ -20,15 +23,16 @@ class ContentActionsHeader extends React.Component {
         //nodeSec: Object {type: "slide", id: 0}
         this.context.executeAction(addTreeNodeAndNavigate, {selector: selector, nodeSpec: nodeSpec});
     }
+
     handleDeleteNode(selector) {
         this.context.executeAction(deleteTreeNodeAndNavigate, selector);
     }
+
     handleEditNode(selector) {
         const nodeURL = ContentUtil.makeNodeURL(selector, 'edit');
-        //user is not logged in
-        if (this.props.UserProfileStore.username === '') {
-            $('.ui.login.modal').modal('toggle');
-        }else{
+        if (this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit) {
+            this.context.executeAction(showNoPermissionsModal, {selector: selector.id, user: this.props.UserProfileStore.userid, permissions: this.props.PermissionsStore.permissions});
+        } else {
             this.context.executeAction(navigateAction, {
                 url: nodeURL
             });
@@ -64,15 +68,16 @@ class ContentActionsHeader extends React.Component {
             iconSize : 'large',
             attached : 'left'
         } ;
+
         return (
             <div className="ui top attached tabular menu" role="tablist">
-                <NavLink activeClass=" " className={'item link' + (contentDetails.mode === 'view' ? ' active' : '')} href={ContentUtil.makeNodeURL(selector, 'view')} role={'tab'}>
+                <NavLink activeClass=" " className={'item link' + (contentDetails.mode === 'view' ? ' active' : '')}  onClick={this.handleEditNode.bind(this, selector)} href={ContentUtil.makeNodeURL(selector, 'view')} role={'tab'}>
                     <i></i>View
                 </NavLink>
                 {this.props.UserProfileStore.username === '' ? '' :
-                <NavLink activeClass=" " className={'item link' + (contentDetails.mode === 'edit' ? ' active' : '')} href={ContentUtil.makeNodeURL(selector, 'edit')} role={'tab'} tabIndex={'0'}>
-                    <i className="ui large blue edit icon "></i> Edit
-                </NavLink>
+                    <div className={'item link' + (contentDetails.mode === 'edit' ? ' active' : '')} onClick={this.handleEditNode.bind(this, selector)} role={'tab'} tabIndex={'0'}>
+                        <i className="ui large blue edit icon "></i> Edit
+                    </div>
                 }
                 {this.props.UserProfileStore.username === '' ? '' :
                     <div className="right menu">

--- a/components/Deck/ContentPanel/NoPermissionsModal.js
+++ b/components/Deck/ContentPanel/NoPermissionsModal.js
@@ -2,11 +2,13 @@ import React from 'react';
 import {connectToStores} from 'fluxible-addons-react';
 import PermissionsStore from '../../../stores/PermissionsStore';
 import forkDeck from '../../../actions/decktree/forkDeck';
-import {NavLink} from 'fluxible-router';
+import {NavLink, navigateAction} from 'fluxible-router';
 import {Button, Icon, Modal, Header} from 'semantic-ui-react';
 import FocusTrap from 'focus-trap-react';
 import _ from 'lodash';
 import hideNoPermissionsModal from '../../../actions/permissions/hideNoPermissionsModal';
+import DeckTreeStore from '../../../stores/DeckTreeStore';
+
 
 class NoPermissionsModal extends React.Component {
 
@@ -22,6 +24,13 @@ class NoPermissionsModal extends React.Component {
         this.context.executeAction(hideNoPermissionsModal);
     }
 
+    navigateToLatestRevision() {
+        this.context.executeAction(navigateAction, {
+            url: '/deck/' + this.props.DeckTreeStore.selector.get('id').split('-')[0] + '-' + this.props.DeckTreeStore.latestRevisionId
+        });
+        this.context.executeAction(hideNoPermissionsModal);
+    }
+
     render() {
         let {isNoPermissionsModalShown, ownedForks, permissions} = this.props.PermissionsStore;
         let headerText, modalDescription, buttons;
@@ -29,8 +38,9 @@ class NoPermissionsModal extends React.Component {
         if (permissions.edit) {
             headerText = 'View-only version';
             modalDescription = 'You are viewing an older version of this deck, which is not available for editing. You can visit the most recent version so you can edit the deck.';
+
             buttons = <div>
-                <NavLink className="ui button" href="/">Go to the latest version</NavLink>
+                <Button as='button' onClick={this.navigateToLatestRevision.bind(this)}>Go to the latest version</Button>
                 {closeButton}
             </div>;
         } else {
@@ -68,9 +78,10 @@ NoPermissionsModal.contextTypes = {
     executeAction: React.PropTypes.func.isRequired
 };
 
-NoPermissionsModal = connectToStores(NoPermissionsModal, [PermissionsStore], (context, props) => {
+NoPermissionsModal = connectToStores(NoPermissionsModal, [PermissionsStore, DeckTreeStore], (context, props) => {
     return {
-        PermissionsStore: context.getStore(PermissionsStore).getState()
+        PermissionsStore: context.getStore(PermissionsStore).getState(),
+        DeckTreeStore: context.getStore(DeckTreeStore).getState()
     };
 });
 export default NoPermissionsModal;

--- a/components/Deck/TreePanel/TreeNode.js
+++ b/components/Deck/TreePanel/TreeNode.js
@@ -72,7 +72,7 @@ class TreeNode extends React.Component {
 
     handleRenameClick(selector, e) {
         //only if user is logged in and has the rights
-        if (this.props.username !== '' && (this.props.permissions.admin || this.props.permissions.edit)) {
+        if (this.props.username !== '' && this.props.permissions.edit && !this.props.permissions.readOnly) {
             this.props.onRename(selector);
             e.stopPropagation();
         }
@@ -151,7 +151,7 @@ class TreeNode extends React.Component {
         let buttonStyle = {
             classNames : classNames({
                 'ui':true,
-                'disabled': !(this.props.permissions.admin || this.props.permissions.edit)
+                'disabled': this.props.permissions.readOnly || !this.props.permissions.edit
             }),            
             iconSize : 'small',
             attached : '',
@@ -237,7 +237,7 @@ class TreeNode extends React.Component {
                 <div onMouseOver={this.handleMouseOver.bind(this)} onMouseOut={this.handleMouseOut.bind(this)}>
                     <i onClick={this.handleExpandIconClick.bind(this, nodeSelector)} className={iconClass}>  </i>
                     {nodeDIV}
-                    {(this.props.username === '' || !(this.props.permissions.admin || this.props.permissions.edit)) ? '' : actionSignifier}
+                    {(this.props.username === '' || !this.props.permissions.edit || this.props.permissions.readOnly) ? '' : actionSignifier}
                 </div>
                 {actionBtns}
                 {childNodesDIV}

--- a/components/Deck/TreePanel/TreePanel.js
+++ b/components/Deck/TreePanel/TreePanel.js
@@ -99,7 +99,7 @@ class TreePanel extends React.Component {
 
     handleMoveNode(sourceNode, targetNode, targetIndex) {
         //only when logged in and having rights
-        if (this.props.UserProfileStore.username !== '' && (this.props.PermissionsStore.permissions.admin || this.props.PermissionsStore.permissions.edit))
+        if (this.props.UserProfileStore.username !== '' && this.props.PermissionsStore.permissions.edit && !this.props.PermissionsStore.permissions.readOnly)
             this.context.executeAction(moveTreeNodeAndNavigate, {
                 selector: this.props.DeckTreeStore.selector.toJS(),
                 sourceNode: sourceNode,

--- a/stores/DeckTreeStore.js
+++ b/stores/DeckTreeStore.js
@@ -13,6 +13,7 @@ class DeckTreeStore extends BaseStore {
         this.error = 0;
         //used to check if the selector is valid and refers to a node that belongs to this deck tree
         this.isSelectorValid = true;
+        this.latestRevisionId = null;
     }
     updateDeckTree(payload) {
         this.isSelectorValid = true;
@@ -43,6 +44,7 @@ class DeckTreeStore extends BaseStore {
         this.updatePrevNextSelectors();
         //reset error state
         this.error = 0;
+        this.latestRevisionId = payload.deckTree.latestRevisionId;
         this.emitChange();
     }
     updatePrevNextSelectors() {
@@ -488,7 +490,8 @@ class DeckTreeStore extends BaseStore {
             prevSelector: this.prevSelector,
             nextSelector: this.nextSelector,
             error: this.error,
-            isSelectorValid: this.isSelectorValid
+            isSelectorValid: this.isSelectorValid,
+            latestRevisionId: this.latestRevisionId
         };
     }
     dehydrate() {
@@ -502,6 +505,7 @@ class DeckTreeStore extends BaseStore {
         this.nextSelector = Immutable.fromJS(state.nextSelector);
         this.error  = state.error;
         this.isSelectorValid = state.isSelectorValid;
+        this.latestRevisionId = state.latestRevisionId;
     }
     handleDeckTreeError(err){
         this.error = err;

--- a/stores/PermissionsStore.js
+++ b/stores/PermissionsStore.js
@@ -35,6 +35,7 @@ class PermissionsStore extends BaseStore {
     }
 
     showNoPermissionsModal(payload) {
+        payload = payload || {};
         this.isNoPermissionsModalShown = true;
         this.ownedForks = payload.ownedForks;
         this.emitChange();

--- a/stores/PermissionsStore.js
+++ b/stores/PermissionsStore.js
@@ -5,10 +5,13 @@ class PermissionsStore extends BaseStore {
         super(dispatcher);
         this.isNoPermissionsModalShown = false;
         this.deckId = null;
+        //the user permissions for the root deck selected
         this.permissions = {
             fork: false,
             edit: false,
-            admin: false
+            admin: false,
+            //used to denote a readonly (non-editable) deck e.g. an old revision
+            readOnly: true
         };
         this.ownedForks = [];
     }
@@ -23,7 +26,8 @@ class PermissionsStore extends BaseStore {
         this.permissions = {
             fork: false,
             edit: false,
-            admin: false
+            admin: false,
+            readOnly: true
         };
         this.deckId = payload.deckId;
         this.ownedForks = [];


### PR DESCRIPTION
This PR addresses issues SWIK-1134 and SWIK-1200. 
It forbids editing older root deck revisions and shows appropriate modal if someone is an editor and tries to edit a read only revision. For people without edit rights, the modal just informs them about ways to gain edit access. Also, a bug is solved when going back through browser history the no permissions modal appears again.