### PR TITLE
Add options in adddecks

### DIFF
--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -245,7 +245,7 @@ class AddDeck extends React.Component {
         if (filename.length > 40)
             filename = filename.substr(0, 40) + ' ...';
 
-        let themeOptions = <select className="ui search dropdown" aria-labelledby="theme" id="themes" ref="select_themes">
+    /*    let themeOptions = <select className="ui search dropdown" aria-labelledby="theme" id="themes" ref="select_themes">
             <option value="default">Default - Reveal.js White</option>
             <option value="beige">Reveal.js Beige</option>
             <option value="black">Reveal.js Black</option>
@@ -256,6 +256,13 @@ class AddDeck extends React.Component {
             <option value="serif">Reveal.js Serif</option>
             <option value="simple">Reveal.js Simple</option>
             <option value="sky">Reveal.js Sky</option>
+            <option value="solarized">Reveal.js Solarized</option>
+        </select>;
+        */
+        let themeOptions = <select className="ui search dropdown" id="theme" aria-labelledby="theme"  ref="select_themes">
+            <option value="default">Default - Reveal.js White</option>
+            <option value="beige">Reveal.js Beige</option>
+            <option value="black">Reveal.js Black</option>
             <option value="solarized">Reveal.js Solarized</option>
         </select>;
         let licenseOptions = <select className="ui search dropdown" aria-labelledby="license" id="license" ref="select_licenses">
@@ -297,7 +304,7 @@ class AddDeck extends React.Component {
                           <textarea rows="4" aria-labelledby="deck-description" id="deck-description" ref="textarea_description" ></textarea>
                       </div>
                       <div className="three fields">
-                          <div className="field disabled" ref="div_themes" >
+                          <div className="field" ref="div_themes" >
                               <label htmlFor="themes">Choose deck theme</label>
                                   {themeOptions}
                           </div>


### PR DESCRIPTION
Does not yet seem to work with adding an imported deck. Perhaps this is
a localhost problem. testing on experimental.

2017-04-15T18:15:50.189Z - info:  Id=-1, Service=deck.js,
Resource=deck.update, Operation=update, Method=POST
2017-04-15T18:15:50.227Z - error:  Id=-1, Actions=[o], User=kadevgraaf,
filepath=/index.js, statusCode=500, message=Cannot read property 'id'
of undefined, url=/api, method=POST, X-Requested-With=XMLHttpRequest,
Content-Type=application/json, url=/api, timeout=30000
2017-04-15T18:15:53.109Z - error:  Id=-1, Actions=[o, r],
User=kadevgraaf, type=Service Unavailable, description=Server is
currently unable to handle the request., actionRequired=Please try
after some time., statusCode=503, statusText=Service Unavailable,
navStack=o, r