### PR TITLE
Swik-1123 apply themes to deck themes tester

### DIFF
--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -263,6 +263,13 @@ class AddDeck extends React.Component {
             <option value="default">Default - Reveal.js White</option>
             <option value="beige">Reveal.js Beige</option>
             <option value="black">Reveal.js Black</option>
+            <option value="blood">Reveal.js Blood</option>
+            <option value="league">Reveal.js League</option>
+            <option value="moon">Reveal.js Moon</option>
+            <option value="night">Reveal.js Night</option>
+            <option value="serif">Reveal.js Serif</option>
+            <option value="simple">Reveal.js Simple</option>
+            <option value="sky">Reveal.js Sky</option>
             <option value="solarized">Reveal.js Solarized</option>
         </select>;
         let licenseOptions = <select className="ui search dropdown" aria-labelledby="license" id="license" ref="select_licenses">

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -391,10 +391,17 @@ class DeckPropertiesEditor extends React.Component {
         let themeOptions = <select className="ui search dropdown" id="theme" aria-labelledby="theme"
                                    value={this.state.theme}
                                    onChange={this.handleChange.bind(this, 'theme')}>
-            <option value="default">Default - Reveal.js White</option>
-            <option value="beige">Reveal.js Beige</option>
-            <option value="black">Reveal.js Black</option>
-            <option value="solarized">Reveal.js Solarized</option>
+           <option value="default">Default - Reveal.js White</option>
+           <option value="beige">Reveal.js Beige</option>
+           <option value="black">Reveal.js Black</option>
+           <option value="blood">Reveal.js Blood</option>
+           <option value="league">Reveal.js League</option>
+           <option value="moon">Reveal.js Moon</option>
+           <option value="night">Reveal.js Night</option>
+           <option value="serif">Reveal.js Serif</option>
+           <option value="simple">Reveal.js Simple</option>
+           <option value="sky">Reveal.js Sky</option>
+           <option value="solarized">Reveal.js Solarized</option>
         </select>;
         /*<option value="blood">Reveal.js Blood</option>
         <option value="league">Reveal.js League</option>

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -41,9 +41,9 @@ class SlideContentEditor extends React.Component {
         else if(this.props.PresentationStore.theme && typeof this.props.PresentationStore.theme !== 'undefined'){
             styleName = this.props.PresentationStore.theme;
         }
-        if (styleName === '' || typeof styleName === 'undefined' || styleName === 'undefined' || styleName === 'default')
+        if (styleName === '' || typeof styleName === 'undefined' || styleName === 'undefined')
         {
-            //if none of above yield a theme:
+            //if none of above yield a theme they will be legacy decks:
             styleName = 'white';
         }
         require('../../../../../custom_modules/reveal.js/css/theme/' + styleName + '.css');

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -34,7 +34,7 @@ class SlideContentEditor extends React.Component {
         this.showTemplates = false;
         // Add the CSS dependency for the theme
         // Get the theme information, and download the stylesheet
-        let styleName = '';
+        let styleName = 'default';
         if(this.props.selector.theme && typeof this.props.selector.theme !== 'undefined'){
             styleName = this.props.selector.theme;
         }

--- a/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
@@ -12,15 +12,22 @@ class SlideViewPanel extends React.Component {
     constructor(props){
         super(props);
 
-        let styleName = 'white';
-        let theme = this.props.PresentationStore.theme;
+        // Add the CSS dependency for the theme
+        // Get the theme information, and download the stylesheet
+        let styleName = '';
         if(this.props.selector.theme && typeof this.props.selector.theme !== 'undefined'){
             styleName = this.props.selector.theme;
         }
-        else if(theme && typeof theme !== 'undefined' && theme !== 'undefined'){
+        else if(this.props.PresentationStore.theme && typeof this.props.PresentationStore.theme !== 'undefined'){
             styleName = this.props.PresentationStore.theme;
         }
-        let req = require('../../../../../custom_modules/reveal.js/css/theme/' + styleName + '.css');
+        if (styleName === '' || typeof styleName === 'undefined' || styleName === 'undefined')
+        {
+            //if none of above yield a theme:
+            styleName = 'white';
+        }
+        require('../../../../../custom_modules/reveal.js/css/theme/' + styleName + '.css');
+
     }
     render() {
 

--- a/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
@@ -14,7 +14,7 @@ class SlideViewPanel extends React.Component {
 
         // Add the CSS dependency for the theme
         // Get the theme information, and download the stylesheet
-        let styleName = '';
+        let styleName = 'default';
         if(this.props.selector.theme && typeof this.props.selector.theme !== 'undefined'){
             styleName = this.props.selector.theme;
         }

--- a/components/Deck/Presentation/Presentation.js
+++ b/components/Deck/Presentation/Presentation.js
@@ -30,14 +30,14 @@ class Presentation extends React.Component{
         this.deck = this.props.PresentationStore.selector.id;
         this.revealDiv = null;
         // Load the theme stylesheet
-        let styleName = 'white';
+        let styleName = 'default';
         if(this.props.PresentationStore.theme && typeof this.props.PresentationStore.theme !== 'undefined'){
             styleName = this.props.PresentationStore.theme;
         }
         //console.log('styleName', styleName);
-        if (styleName === '' || typeof styleName === 'undefined' || styleName === 'undefined' || styleName === 'default')
+        if (styleName === '' || typeof styleName === 'undefined' || styleName === 'undefined')
         {
-            //if none of above yield a theme:
+            //if none of above yield a theme they will be legacy decks:
             styleName = 'white';
         }
         require('../../../custom_modules/reveal.js/css/theme/' + styleName + '.css');


### PR DESCRIPTION
This PR requires that the SWIK-983 change in the reveal.js submodule also be complete.

Main change is that we don't return white.css as a theme if we have a theme with "default".  The white.css file should only be used for legacy, and default.css should be used for the new themes.

It also adds in all themes for the addDeck component, since they should all be ready for deployment. 

A bug with the display in view and possibly edit mode is highlighted with this change, particularly on e.g., serif, but this existed anyway, and came as a result of changing the .reveal div to position:absolute.  I'll create a separate ticket for that.