### PR TITLE
Swik 1216 prevent undefined values in activitiesservice calls

### DIFF
--- a/components/Deck/ActivityFeedPanel/ActivityFeedPanel.js
+++ b/components/Deck/ActivityFeedPanel/ActivityFeedPanel.js
@@ -25,7 +25,10 @@ class ActivityFeedPanel extends React.Component {
     render() {
         let pointingMenu = '';
         let activityDIV = '';
-        const hrefPath = '/activities/' + this.props.ActivityFeedStore.selector.stype + '/' + this.props.ActivityFeedStore.selector.sid;
+        let hrefPath = '/activities/' + this.props.ActivityFeedStore.selector.stype + '/' + this.props.ActivityFeedStore.selector.sid;
+        if (this.props.ActivityFeedStore.selector.stype === undefined || this.props.ActivityFeedStore.selector.sid === undefined) {
+            hrefPath = '';
+        }
 
         activityDIV = <ActivityList />;
 

--- a/components/Deck/ActivityFeedPanel/ActivityItem.js
+++ b/components/Deck/ActivityFeedPanel/ActivityItem.js
@@ -60,7 +60,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big translate icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'translated '} {nodeRef} {' to '}
                         {/*<a href={'/slideview/' + node.translation_info.content_id}>{node.translation_info.language}</a>*/}
@@ -74,7 +74,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big slideshare icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'shared '} {nodeRef} {' on '}
                         <a target="_blank" href={node.share_info.postURI}>{node.share_info.platform}</a>
@@ -87,7 +87,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big write icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'created '} {nodeRef}
                         <br/>
@@ -99,7 +99,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big edit icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'edited '} {nodeRef}
                         <br/>
@@ -111,7 +111,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big comment outline icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'commented on '} {nodeRef}
                         <br/>
@@ -125,7 +125,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big comments outline icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a>
                         <span> replied to a comment </span>{'on ' } {nodeRef}
@@ -140,7 +140,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big copy icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'used '} {nodeRef}
                         {' in deck '}<a href={'/deckview/' + node.use_info.target_id}>{node.use_info.target_name}</a>
@@ -153,7 +153,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big empty star icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'rated '} {nodeRef}
                         <br/>
@@ -165,7 +165,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big thumbs outline up icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'liked '} {nodeRef}
                         <br/>
@@ -177,7 +177,7 @@ class ActivityItem extends React.Component {
                 IconNode = (<i className="ui big download icon"></i>);
                 SummaryNode = (
                     <div className="summary">
-                        <a className="user" href={'/user/' + node.user_id}>
+                        <a className="user" href={node.user_id ? '/user/' + node.user_id : ''}>
                             {node.author ? node.author.username : 'unknown'}
                         </a> {'downloaded '} {nodeRef}
                         <br/>

--- a/services/activities.js
+++ b/services/activities.js
@@ -4,23 +4,6 @@ import rp from 'request-promise';
 import { isEmpty } from '../common.js';
 const log = require('../configs/log').log;
 
-// function adjustIDs(activity) {
-//     activity.content_id = adjustID(activity.content_id);
-//     activity.user_id = adjustID(activity.user_id);
-//     if (activity.translation_info !== undefined)
-//         activity.translation_info.content_id = adjustID(activity.translation_info.content_id);
-//     if (activity.comment_info !== undefined)
-//         activity.comment_info.comment_id = adjustID(activity.comment_info.comment_id);
-//     if (activity.use_info !== undefined)
-//         activity.use_info.target_id = adjustID(activity.use_info.target_id);
-// }
-// function adjustID(id) {
-//     if (id.length === 24 && id.startsWith('1122334455')) {
-//         return id.substring(20).replace(/^0+/, '');
-//     }
-//     return id;
-// }
-
 export default {
     name: 'activities',
     // At least one of the CRUD methods is Required
@@ -30,50 +13,37 @@ export default {
         let args = params.params? params.params : params;
         let selector= {'id': args.id, 'spath': args.spath, 'sid': args.sid, 'stype': args.stype, 'mode': args.mode};
 
-        // const content_id = (!selector.sid.startsWith('1122334455')) ? ('112233445566778899000000'.substring(0, 24 - selector.sid.length) + selector.sid) : selector.sid;//TODO solve these ID issues
         const content_kind = selector.stype;
         const content_id = selector.sid;
-        switch (resource) {
-            case 'activities.list':
 
-                // callback(null, {activities: initialActivities.concat(generateRandomActivities(30, 11)), selector: selector, hasMore: true});
+        if (content_kind === undefined || content_id === undefined) {//prevent calls with invalid values
+            callback(null, {activities: [], selector: selector, hasMore: false});
+        } else {
+            switch (resource) {
+                case 'activities.list':
+                    rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/0/30' }).then((res) => {
+                        let activities = JSON.parse(res);
+                        callback(null, {activities: activities, selector: selector, hasMore: (activities.length === 30)});
+                    }).catch((err) => {
+                        console.log(err);
+                        callback(null, {activities: [], selector: selector, hasMore: false});
+                    });
 
-                rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/0/30' }).then((res) => {
-                    let activities = JSON.parse(res);
+                    break;
+                case 'activities.more':
 
-                    // activities.forEach((activity) => adjustIDs(activity));//TODO solve these ID issues
+                    if (!params.newActivities) break;
 
-                    callback(null, {activities: activities, selector: selector, hasMore: (activities.length === 30)});
-                }).catch((err) => {
-                    console.log(err);
-                    callback(null, {activities: [], selector: selector, hasMore: false});
-                });
+                    rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/' + params.newActivities.start + '/' + params.newActivities.numNew }).then((res) => {
+                        let activities = JSON.parse(res);
+                        callback(null, {activities: activities, selector: selector, hasMore: (activities.length === 30)});
+                    }).catch((err) => {
+                        console.log(err);
+                        callback(null, {activities: [], selector: selector, hasMore: false});
+                    });
 
-                break;
-            case 'activities.more':
-
-                if (!params.newActivities) break;
-                // setTimeout(() => {
-                //     let hasMoreActivities = true;
-                //     let newActivities = [];
-                //     const startID = params.newActivities.latestId+1;
-                //     if (startID < 200) newActivities = generateRandomActivities(params.newActivities.numNew, startID);
-                //     if (startID + params.newActivities.numNew > 200) hasMoreActivities = false;
-                //     callback(null, {activities: newActivities, hasMore: hasMoreActivities});
-                // }, 500);
-
-                rp.get({uri: Microservices.activities.uri + '/activities/' + content_kind + '/' + content_id + '/more/' + params.newActivities.start + '/' + params.newActivities.numNew }).then((res) => {
-                    let activities = JSON.parse(res);
-
-                    // activities.forEach((activity) => adjustIDs(activity));//TODO solve these ID issues
-
-                    callback(null, {activities: activities, selector: selector, hasMore: (activities.length === 30)});
-                }).catch((err) => {
-                    console.log(err);
-                    callback(null, {activities: [], selector: selector, hasMore: false});
-                });
-
-                break;
+                    break;
+            }
         }
     },
     create: (req, resource, params, body, config, callback) => {

--- a/services/activities.js
+++ b/services/activities.js
@@ -17,6 +17,7 @@ export default {
         const content_id = selector.sid;
 
         if (content_kind === undefined || content_id === undefined) {//prevent calls with invalid values
+            log.error({Id: req.reqId, Selector: selector, Message: 'Invalid selector values in activities service'});
             callback(null, {activities: [], selector: selector, hasMore: false});
         } else {
             switch (resource) {


### PR DESCRIPTION
This fix solves the problem with undefined values in activity-service calls.
Content_kind and content_id are validated before sending a request to the activity-service.
Also, links in ActivityFeedPanel and ActivityItem are modified in case of invalid data.