### PR TITLE
SWIK-1216 Fixing redirection/deck metadata update after import

### DIFF
--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -116,7 +116,8 @@ class AddDeck extends React.Component {
             license: license,
             tags: tags,
             userid: this.props.UserProfileStore.userid,
-            deckId: this.props.ImportStore.deckId
+            deckId: this.props.ImportStore.deckId,
+            selector: {id: this.props.ImportStore.deckId}
         });
     }
     handleCancel(x) {


### PR DESCRIPTION
Added selector.id to the list of parameters. This is required for the top_root_deck parameter in deck.update (deck.js, line 216).