### PR TITLE
Swik 568 refine progress bar

### DIFF
--- a/actions/import/uploadFile.js
+++ b/actions/import/uploadFile.js
@@ -14,7 +14,7 @@ export default function uploadFile(context, payload, done) {
     const timeout = 60;
     const remainingProgress = 55;
     let currentProgress = 0;
-    const updatePeriod = payload.base64.length / 20 / 1000 / 1024 ; // progress bar speed depends on file length
+    const updatePeriod = payload.base64.length / 30 / 1000 / 1024 ; // progress bar speed depends on file length
     const progressStep = 1;
     const timer = () => {
         setTimeout(() => {

--- a/actions/import/uploadFile.js
+++ b/actions/import/uploadFile.js
@@ -40,16 +40,13 @@ export default function uploadFile(context, payload, done) {
         if (err) {
             log.error(context, {filepath: __filename, err: err});
             context.executeAction(serviceUnavailable, payload, done);
-            //context.dispatch('UPLOAD_FAILED', err);
-            //context.dispatch('CREATION_FAILURE', err);
         } else {
-            //TODO: use correct headers - atm service is not ready
             if (res.deckid === undefined) {
                 context.dispatch('UPLOAD_FAILED', err);
                 context.dispatch('CREATION_FAILURE', err);
+            } else {
+                context.dispatch('UPLOAD_SUCCESS', res);
             }
-
-            context.dispatch('UPLOAD_SUCCESS', res);
         }
         done();
     });

--- a/actions/import/uploadFile.js
+++ b/actions/import/uploadFile.js
@@ -7,28 +7,30 @@ export default function uploadFile(context, payload, done) {
     log.info(context);
     context.dispatch('UPLOAD_STARTED', null);
 
-    //use timer in order to make a working progress bar
-    // context.myStuff = {
-    //     uploadFinished: false
-    // };
+    // use timer in order to make a working progress bar
+    context.myStuff = {
+        uploadFinished: false
+    };
     const timeout = 60;
-    // const remainingProgress = 89;
-    // const updatePeriod = 3; //3 seconds
-    // const progressPerThreeSeconds = (timeout / remainingProgress) * updatePeriod + 1;
-    // const timer = () => {
-    //     setTimeout(() => {
-    //         if (!context.myStuff.uploadFinished) {
-    //             context.dispatch('UPLOAD_MORE_PROGRESS', progressPerThreeSeconds);
-    //             timer();
-    //         }
-    //     }, updatePeriod * 1000);
-    // };
-    // timer();
+    const remainingProgress = 55;
+    let currentProgress = 0;
+    const updatePeriod = payload.base64.length / 20 / 1000 / 1024 ; // progress bar speed depends on file length
+    const progressStep = 1;
+    const timer = () => {
+        setTimeout(() => {
+            if (!context.myStuff.uploadFinished && currentProgress < remainingProgress) {
+                currentProgress += progressStep;
+                context.dispatch('UPLOAD_MORE_PROGRESS', progressStep);
+                timer();
+            }
+        }, updatePeriod * 1000);
+    };
+    timer();
 
     context.service.create('import', payload, {timeout: timeout * 1000}, {timeout: timeout * 1000}, (err, res) => {
         //console.log('action got response from server', err);
 
-        // context.myStuff.uploadFinished = true;
+        context.myStuff.uploadFinished = true;
         if (err) {
             log.error(context, {filepath: __filename, err: err});
             context.executeAction(serviceUnavailable, payload, done);

--- a/actions/import/uploadFile.js
+++ b/actions/import/uploadFile.js
@@ -11,19 +11,22 @@ export default function uploadFile(context, payload, done) {
     context.myStuff = {
         uploadFinished: false
     };
-    const timeout = 60;
+    const timeout = 120;
     const remainingProgress = 55;
     let currentProgress = 0;
-    const updatePeriod = 3; //3 seconds
-    let progressPerThreeSeconds = parseInt(40 * 1024 * 1024 / payload.base64.length) + 1;
+    const averageUploadSpeed = 0.5; // MB/s
+    const updatePeriod = 2; // 2 seconds
+    const MBPerUpdatePeriod = updatePeriod * averageUploadSpeed;
+    const noOfUpdatePeriods = payload.base64.length / MBPerUpdatePeriod / 1024 / 1024;
+    let progressPerUpdatePeriod = parseInt(remainingProgress / noOfUpdatePeriods) + 1;
     const timer = () => {
         setTimeout(() => {
             if (!context.myStuff.uploadFinished && currentProgress < remainingProgress) {
-                currentProgress += progressPerThreeSeconds;
+                currentProgress += progressPerUpdatePeriod;
                 if (currentProgress > remainingProgress) {
-                    progressPerThreeSeconds -= currentProgress - remainingProgress;
+                    progressPerUpdatePeriod -= currentProgress - remainingProgress;
                 }
-                context.dispatch('UPLOAD_MORE_PROGRESS', progressPerThreeSeconds);
+                context.dispatch('UPLOAD_MORE_PROGRESS', progressPerUpdatePeriod);
                 timer();
             }
         }, updatePeriod * 1000);

--- a/actions/import/uploadFile.js
+++ b/actions/import/uploadFile.js
@@ -14,13 +14,16 @@ export default function uploadFile(context, payload, done) {
     const timeout = 60;
     const remainingProgress = 55;
     let currentProgress = 0;
-    const updatePeriod = payload.base64.length / 30 / 1000 / 1024 ; // progress bar speed depends on file length
-    const progressStep = 1;
+    const updatePeriod = 3; //3 seconds
+    let progressPerThreeSeconds = parseInt(40 * 1024 * 1024 / payload.base64.length) + 1;
     const timer = () => {
         setTimeout(() => {
             if (!context.myStuff.uploadFinished && currentProgress < remainingProgress) {
-                currentProgress += progressStep;
-                context.dispatch('UPLOAD_MORE_PROGRESS', progressStep);
+                currentProgress += progressPerThreeSeconds;
+                if (currentProgress > remainingProgress) {
+                    progressPerThreeSeconds -= currentProgress - remainingProgress;
+                }
+                context.dispatch('UPLOAD_MORE_PROGRESS', progressPerThreeSeconds);
                 timer();
             }
         }, updatePeriod * 1000);

--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -346,7 +346,7 @@ class AddDeck extends React.Component {
                   </div>
                   <div className="ui progress" ref="div_progress" id="progressbar_addDeck_upload" >
                       <div className="bar">
-                          <div className="progress"></div>
+                          <div className="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                       <div className="label" ref="div_progress_text" id="progresslabel_addDeck_upload"></div>
                   </div>

--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -142,12 +142,12 @@ class AddDeck extends React.Component {
         $('#progressbar_addDeck_upload').progress('set percent', this.props.ImportStore.uploadProgress);
         let noOfSlides = String(this.props.ImportStore.noOfSlides);
         let totalNoOfSlides = String(this.props.ImportStore.totalNoOfSlides);
-        let progressLabel = (totalNoOfSlides === '0') ? 'Uploading file' :
-          (noOfSlides === '1' && totalNoOfSlides !== '1') ? 'Converting file' :
+        let progressLabel = (totalNoOfSlides === '0' && this.props.ImportStore.uploadProgress < 65) ? 'Uploading file' :
+          (this.props.ImportStore.uploadProgress === 65) ? 'Converting file' :
           (this.props.ImportStore.uploadProgress !== 100) ? 'Importing slide ' + noOfSlides + ' of ' + totalNoOfSlides :
           (noOfSlides === totalNoOfSlides) ? 'Slides uploaded!' :
           'Imported ' + noOfSlides  + ' of ' + totalNoOfSlides + ' slides';//this should not happen, but user should know in case it does
-        $('#progresslabel_addDeck_upload').text(progressLabel);
+        $('#progresslabel_addDeck_upload').text(parseInt(this.props.ImportStore.uploadProgress) + '% - ' + progressLabel);
     }
     initializeProgressBar() {
         $('#progressbar_addDeck_upload').progress('set active');
@@ -344,11 +344,9 @@ class AddDeck extends React.Component {
                           </div>
                       </div>
                   </div>
-                  <div className="ui progress" ref="div_progress" id="progressbar_addDeck_upload" >
-                      <div className="bar">
-                          <div className="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-                      </div>
-                      <div className="label" ref="div_progress_text" id="progresslabel_addDeck_upload"></div>
+                  <div className="ui indicating progress" ref="div_progress" id="progressbar_addDeck_upload" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" tabIndex="0" >
+                      <div className="bar"></div>
+                      <div className="label" ref="div_progress_text" id="progresslabel_addDeck_upload" aria-live="polite"></div>
                   </div>
                       <div className={fieldClass_conditions} >
                           <div className="ui checkbox" ref="div_conditions" >

--- a/services/import.js
+++ b/services/import.js
@@ -13,7 +13,7 @@ export default {
 
         //let keys = [];
         //for(let k in params) keys.push(k);
-        console.log('import service', params.file, params.base64.length);
+        // console.log('import service', params.file, params.base64.length);
 
         //create a HTTP POST form request
         form.append('file', params.base64);
@@ -42,7 +42,7 @@ export default {
                 return;
             }
 
-            console.log('result of call to import-microservice', res.headers, res.statusCode);
+            // console.log('result of call to import-microservice', res.headers, res.statusCode);
             //res does not contain any data ...
             //the response data have to be send via headers
             callback(null, res.headers);

--- a/stores/ImportStore.js
+++ b/stores/ImportStore.js
@@ -62,7 +62,7 @@ class ImportStore extends BaseStore {
     }
 
     storeFile(payload) {
-        console.log('ImportStore: storeFile()', payload);
+        // console.log('ImportStore: storeFile()', payload);
         this.file = payload.file;
         this.base64 = payload.base64;
         this.filename = this.file.name;
@@ -83,7 +83,7 @@ class ImportStore extends BaseStore {
         this.emitChange();
     }
     uploadSuccess(headers) {
-        console.log('ImportStore: uploadSuccess()', headers);
+        // console.log('ImportStore: uploadSuccess()', headers);
         this.isUploaded = true;
         // this.uploadProgress = 100;
         this.uploadProgress = 65;
@@ -97,7 +97,7 @@ class ImportStore extends BaseStore {
         this.emitChange();
     }
     uploadStarted() {
-        console.log('ImportStore: uploadStarted()');
+        // console.log('ImportStore: uploadStarted()');
         this.uploadProgress = 10;
         this.error = null;
         this.noOfSlides = 0;

--- a/stores/ImportStore.js
+++ b/stores/ImportStore.js
@@ -86,7 +86,7 @@ class ImportStore extends BaseStore {
         console.log('ImportStore: uploadSuccess()', headers);
         this.isUploaded = true;
         // this.uploadProgress = 100;
-        this.uploadProgress = 33;
+        this.uploadProgress = 65;
         this.deckId = headers.deckid;
         this.totalNoOfSlides = parseInt(headers.noofslides);
 
@@ -106,7 +106,7 @@ class ImportStore extends BaseStore {
         this.emitChange();
     }
     uploadMoreProgress(progress) {
-        console.log('ImportStore: uploadMoreProgress()', progress);
+        // console.log('ImportStore: uploadMoreProgress()', progress);
         if (this.uploadProgress === 100)
             return;
 


### PR DESCRIPTION
This branch improves L&F of the import progress bar.
While uploading a file, the progress bar percentage is increased every 2s (reintroducing Kurt's code, with some modifications), until 65%, for the amount which is calculated based on the file size. Since currently we don't have the real information about the file upload progress, this calculation is an estimation and will be more or less accurate depending on the user's network upload speed. If, after reaching 65%, the upload is not yet finished, the message will change from 'Uploading file' to 'Converting file'.
Accessibility is also improved.