### PR TITLE
Swik 1239 fix activity feed width

### DIFF
--- a/components/Deck/ActivityFeedPanel/ActivityFeedPanel.js
+++ b/components/Deck/ActivityFeedPanel/ActivityFeedPanel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {NavLink} from 'fluxible-router';
 import { connectToStores } from 'fluxible-addons-react';
 import classNames from 'classnames/bind';
 import loadActivities from '../../../actions/activityfeed/loadActivities';
@@ -23,22 +24,26 @@ class ActivityFeedPanel extends React.Component {
     }
 
     render() {
-        let pointingMenu = '';
         let activityDIV = '';
         let hrefPath = '/activities/' + this.props.ActivityFeedStore.selector.stype + '/' + this.props.ActivityFeedStore.selector.sid;
         if (this.props.ActivityFeedStore.selector.stype === undefined || this.props.ActivityFeedStore.selector.sid === undefined) {
             hrefPath = '';
         }
 
+        const panelDIVStyles = {
+            maxHeight: 400,
+            overflowY: 'auto'
+        };
+
         activityDIV = <ActivityList />;
 
         return (
             <div ref="activityFeedPanel">
-                <div className="ui compact segments">
+                <div className="ui segments">
                     <div className="ui secondary segment">
-                        <a href={hrefPath}>Activity Feed</a>
+                        <NavLink href={hrefPath}>Activity Feed</NavLink>
                     </div>
-                    <div className="ui segment attached">
+                    <div className="ui segment" style={panelDIVStyles}>
                         {activityDIV}
                     </div>
                 </div>

--- a/components/Deck/ActivityFeedPanel/ActivityList.js
+++ b/components/Deck/ActivityFeedPanel/ActivityList.js
@@ -45,7 +45,7 @@ class ActivityList extends React.Component {
                 <ReactList ref="infiniteList" className="ui list"
                     itemRenderer={this.renderItem.bind(this)}
                     length={this.props.ActivityFeedStore.activities.length}
-                    type={'variable'}>
+                    type={'simple'}>
                 </ReactList>
               }
             </div>

--- a/components/Deck/ActivityFeedPanel/ActivityList.js
+++ b/components/Deck/ActivityFeedPanel/ActivityList.js
@@ -36,48 +36,8 @@ class ActivityList extends React.Component {
         this.loading = false;
     }
     render() {
-        ////////////////////////////////////////////////////////
-        //legacy code (commented below), can be removed probably
-        ////////////////////////////////////////////////////////
-
-        //let rows = [];
-        //let currentRow = [];
-        //this.props.ActivityFeedStore.activities.forEach((item) => {
-        //    if (currentRow.length % 3 === 0 && currentRow.length > 0) {
-        //        rows.push((
-        //            <div className="row" key={rows.length}>
-        //                {currentRow}
-        //            </div>
-        //        ));
-        //        currentRow = [];
-        //    }
-        //    currentRow.push((
-        //        <div className="ui column" key={currentRow.length}>
-        //            <ActivityItem activity={item} />
-        //        </div>
-        //    ));
-        //});
-        //if (currentRow.length > 0) {
-        //    rows.push((
-        //        <div className="row" key={rows.length}>
-        //            {currentRow}
-        //        </div>
-        //    ));
-        //}
-        //let list = this.props.ActivityFeedStore.activities.map((node, index) => {
-        //    return (
-        //        <div className="ui item" key={index} style={{ margin: '1em 0'}}>
-        //            <ActivityItem activity={node} />
-        //        </div>
-        //    );
-        //});
-
-        const listStyles = {
-            maxHeight: '400px',
-            overflowY: 'auto'
-        };
         return (
-            <div ref="activityList" style={listStyles}>
+            <div ref="activityList">
                 {(this.props.ActivityFeedStore.activities.length === 0)
                 ?
                 <div>There are currently no activities for this {this.props.ActivityFeedStore.selector.stype}.</div>

--- a/components/Deck/Deck.js
+++ b/components/Deck/Deck.js
@@ -125,23 +125,25 @@ class Deck extends React.Component {
                         </div>
                     </div>
                 </div>
-                    
-                    <div className={rightColClass}>
-                         <TreePanel mode={this.props.DeckPageStore.mode} page={this.props.DeckPageStore.page}/>
-                        </div>
-                        <div className="ui hidden divider"></div>
-                        <div className={ActivityFeedPanelClass}>
-                            <div className="row">
-                                <ActivityFeedPanel />
-                            </div>
-                        </div>
-                        <div className="ui hidden divider"></div>
+
+                <div className={rightColClass}>
+                    <div className={treePanelClass}>
+                        <TreePanel mode={this.props.DeckPageStore.mode} page={this.props.DeckPageStore.page}/>
                     </div>
-               
-             
+                    <div className="ui hidden divider"></div>
+                    <div className={ActivityFeedPanelClass}>
+                        <div className="row">
+                            <ActivityFeedPanel />
+                        </div>
+                    </div>
+                    <div className="ui hidden divider"></div>
+                </div>
+
+
 
                 </div>
-         
+            </div>
+
         );
     }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-intl": "^2.2.3",
     "react-intl-webpack-plugin": "0.0.3",
     "react-image-cropper": "^1.0.5",
-    "react-list": "^0.8.3",
+    "react-list": "^0.8.6",
     "react-resize-aware": "^1.0.11",
     "react-responsive": "^1.2.6",
     "request": "^2.80.0",


### PR DESCRIPTION
Fixing Activity feed panel layout. Minor changes - some styles were modified to fix panel width.
Also fixed SWIK-1198 'Activity feed shows only the bottom element after hiding the decktree', by changing ReactList type to 'simple'.