### PR TITLE
Swik 1410 fix label of import progress bar

### DIFF
--- a/stores/ImportStore.js
+++ b/stores/ImportStore.js
@@ -133,7 +133,7 @@ class ImportStore extends BaseStore {
                 }
             }
         } else {
-            if (++this.safetyCounter > 100) {//50 times the call was made, and no change in noOfSlides
+            if (++this.safetyCounter > 100) {//100 times the call was made, and no change in noOfSlides
                 this.uploadProgress = 100;
             }
         }

--- a/stores/ImportStore.js
+++ b/stores/ImportStore.js
@@ -118,16 +118,22 @@ class ImportStore extends BaseStore {
         this.emitChange();
     }
     slidesProgress(res) {
-        if (this.noOfSlides < res.noofslides) {
-            this.safetyCounter = 0;
+        if (this.noOfSlides < res.noofslides) {//no of slides has changed
             this.noOfSlides = res.noofslides;
-            if (this.noOfSlides < this.totalNoOfSlides) {
-                this.uploadProgress = 66 + 34 * (this.noOfSlides / this.totalNoOfSlides);
-            } else {
-                this.uploadProgress = 100;
+            if (this.noOfSlides === 1) {//only one slide imported - still converting (progress should stay at 'converting') or one-slide presentation?
+                if (this.totalNoOfSlides === 1) {//one-slide presentation - complete
+                    this.uploadProgress = 100;
+                }
+            } else {//more than one slide has been created ( show progress after 'converting')
+                this.safetyCounter = 0;
+                if (this.noOfSlides < this.totalNoOfSlides) {
+                    this.uploadProgress = 66 + 34 * (this.noOfSlides / this.totalNoOfSlides);
+                } else {
+                    this.uploadProgress = 100;
+                }
             }
         } else {
-            if (++this.safetyCounter > 50) {//50 times the call was made, and no change in noOfSlides
+            if (++this.safetyCounter > 100) {//50 times the call was made, and no change in noOfSlides
                 this.uploadProgress = 100;
             }
         }


### PR DESCRIPTION
This is a small fix for the import progress bar. It sets the message 'Converting' to be displayed while waiting for the number of slides (received from the deck-service) to start increasing (meaning that the import-service has created the deck with 1 slide and is in the process of converting the rest of the slides). This is significant when importing larger presentations.