### PR TITLE
UserLanguage fix

### DIFF
--- a/services/userProfile.js
+++ b/services/userProfile.js
@@ -41,7 +41,7 @@ export default {
                 username: params.uname,
                 surname: !isEmpty(params.lname) ? params.lname : '',
                 forename: !isEmpty(params.fname) ? params.fname : '',
-                language: !isEmpty(params.language) ? params.language : '',
+                language: !isEmpty(params.language) ? params.language.replace('-', '_') : '',
                 country: !isEmpty(params.country) ? params.country : '',
                 picture: !isEmpty(params.picture) ? params.picture : '',
                 organization: !isEmpty(params.organization) ? params.organization : '',
@@ -77,7 +77,7 @@ export default {
                     token: params.token,
                     token_creation: params.token_creation,
                     email: params.email,
-                    language: params.language
+                    language: params.language.replace('-', '_')
                 }
             })
               .then((body) => callback(null, body))


### PR DESCRIPTION
Languages might be saved in the db as "xx-XX", but the user-service only accepts (due to a recent change) "xx_XX". This PR makes sure that issued data is always in the allowed format and thereof transformes all the database entries to the right format over time. This prevents to execute a migration script on the database (also for testing and stable deployments).

This will fix the error for uploading new user pictures (settings of a user)