### PR TITLE
SWIK-1454 Using selector from props

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {connectToStores} from 'fluxible-addons-react';
-import ContentDiscussionStore from '../../../../stores/ContentDiscussionStore';
 import UserProfileStore from '../../../../stores/UserProfileStore';
 import addComment from '../../../../actions/contentdiscussion/addComment';
 import invertCommentBoxFlag from '../../../../actions/contentdiscussion/invertCommentBoxFlag';
@@ -26,7 +25,7 @@ class AddComment extends React.Component {
         e.preventDefault();
         if (this.refs.title.value !== '' && this.refs.text.value !== '') {
             this.context.executeAction(addComment, {
-                selector: this.props.ContentDiscussionStore.selector,
+                selector: this.props.selector,
                 title: this.refs.title.value,
                 text: this.refs.text.value,
                 userid: this.props.UserProfileStore.userid
@@ -70,9 +69,8 @@ AddComment.contextTypes = {
     executeAction: React.PropTypes.func.isRequired
 };
 
-AddComment = connectToStores(AddComment, [ContentDiscussionStore, UserProfileStore], (context, props) => {
+AddComment = connectToStores(AddComment, [UserProfileStore], (context, props) => {
     return {
-        ContentDiscussionStore: context.getStore(ContentDiscussionStore).getState(),
         UserProfileStore: context.getStore(UserProfileStore).getState()
     };
 });

--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/ContentDiscussionPanel.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/ContentDiscussionPanel.js
@@ -21,8 +21,9 @@ class ContentDiscussionPanel extends React.Component {
                 <NavLink href={'/discussion/' + this.props.ContentDiscussionStore.selector.stype + '/' + this.props.ContentDiscussionStore.selector.sid}>{'/discussion/' + this.props.ContentDiscussionStore.selector.stype + '/' + this.props.ContentDiscussionStore.selector.sid}</NavLink>
             </div>
         );
+        const selector = (this.props.selector !== undefined && this.props.selector !== {}) ? this.props.selector : this.props.ContentDiscussionStore.selector;
         let addComment = (this.props.ContentDiscussionStore.showCommentBox) ?
-            (<AddComment/>)
+            (<AddComment selector={selector} />)
             :
             (<button tabIndex="0" className="ui blue labeled icon button" onClick={this.handleInvertCommentBox.bind(this)}>
                 <i className="icon plus"></i> Add comment
@@ -34,7 +35,7 @@ class ContentDiscussionPanel extends React.Component {
                 <h3 className="ui dividing header">Comments</h3>
                 {(this.props.ContentDiscussionStore.discussion.length === 0)
                     ?
-                    <div>There are currently no comments for this {this.props.ContentDiscussionStore.selector.stype}.</div>
+                    <div>There are currently no comments for this {selector.stype}.</div>
                     :
                     <div style={{ maxHeight: '600px', overflowY: 'auto' }}>
                         {this.props.ContentDiscussionStore.discussion.map((comment, index) => { return (<Comment key={index} comment={comment} userid={this.props.UserProfileStore.userid} />); })}


### PR DESCRIPTION
This is a small bugfix.
It was discovered that a comment is sometimes added to the wrong node. This was due to the invalid selector which was used. This branch fixes this by passing proper selector as a property of the component.