### PR TITLE
Swik 1455 unrequire comment text

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddComment.js
@@ -24,7 +24,7 @@ class AddComment extends React.Component {
 
     handleAddComment(e) {
         e.preventDefault();
-        if (this.refs.title.value !== '' && this.refs.text.value !== '') {
+        if (this.refs.title.value !== '') {
             this.context.executeAction(addComment, {
                 selector: this.props.ContentDiscussionStore.selector,
                 title: this.refs.title.value,
@@ -49,9 +49,9 @@ class AddComment extends React.Component {
                   <label>Comment title</label>
                   <input type="text" ref="title" id="title" name="title" placeholder="Title" autoFocus required />
               </div>
-              <div className="ui required field">
+              <div className="ui field">
                   <label>Comment text</label>
-                  <textarea ref="text" id="text" name="text" style={{minHeight: '6em', height: '6em'}} placeholder="Text" required ></textarea>
+                  <textarea ref="text" id="text" name="text" style={{minHeight: '6em', height: '6em'}} placeholder="Text" ></textarea>
               </div>
 
               <button tabIndex="0" type="submit" className="ui blue labeled submit icon button" >

--- a/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddReply.js
+++ b/components/Deck/ContentModulesPanel/ContentDiscussionPanel/AddReply.js
@@ -21,7 +21,7 @@ class AddReply extends React.Component {
 
     handleAddReply(e) {
         e.preventDefault();
-        if (this.refs.replytitle.value !== '' && this.refs.replytext.value !== '') {
+        if (this.refs.replytitle.value !== '') {
             this.context.executeAction(addReply, {
                 comment: this.props.comment,
                 title: this.refs.replytitle.value,
@@ -42,9 +42,9 @@ class AddReply extends React.Component {
                   <label>Reply title</label>
                   <input type="text" ref="replytitle" id="replytitle" name="replytitle" defaultValue={replyTitle} required/>
               </div>
-              <div className="ui required field">
+              <div className="ui field">
                   <label>Reply text</label>
-                  <textarea ref="replytext" id="replytext" name="replytext" style={{minHeight: '6em', height: '6em'}} placeholder="Text" autoFocus required></textarea>
+                  <textarea ref="replytext" id="replytext" name="replytext" style={{minHeight: '6em', height: '6em'}} placeholder="Text" autoFocus></textarea>
               </div>
               <button tabIndex="0" type="submit" className="ui blue labeled submit icon button" >
                   <i className="icon edit"></i> Add Reply


### PR DESCRIPTION
This is a small fix which allows adding comment (and replies) without the text of the comment. The title field is still required.
Required changes on the discussion-service side are already implemented.