### PR TITLE
Created license info page, added link to footer; improved layout About page

### DIFF
--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -4,25 +4,33 @@ import { NavLink } from 'fluxible-router';
 class Footer extends React.Component {
     render() {
         return (
-            <div className="ui horizontal segments footer" ref="footer">
-                    <div className="ui right aligned segment">
-                        <p>
-                            Copyright &copy; 2016 &middot; All Rights Reserved
-                        </p>
-                    </div>
-                    <div className="ui left aligned segment">
-                        <NavLink className="item" routeName="about">About</NavLink>
-                         &nbsp;&middot;&nbsp;
-                        <NavLink className="item" routeName="imprint">Imprint</NavLink>
-                         &nbsp;&middot;&nbsp;
-                        <NavLink className="item" routeName="dataprotection">Data Protection Conditions</NavLink>
-                    </div>
-                    <div className="ui left aligned segment">
-                        <p>
-                            Build GIT_COMMIT&#64;GIT_BRANCH
-                        </p>
-                    </div>
+          <div className="ui blue inverted vertical footer segment" ref="footer" style={{marginTop: '10px', paddignTop: '10px'}}>
+            <div className="ui container">
+
+            <div className="ui stackable inverted divided equal height stackable grid">
+              <div className="three wide column">
+                <h4 className="ui inverted header">About</h4>
+                <div className="ui inverted link list">
+                  <NavLink className="item" routeName="about" href="/about">About Us</NavLink>
+                  <NavLink className="item" routeName="about" href="/about">Contact Us</NavLink>
+                </div>
+              </div>
+              <div className="three wide column">
+                <h4 className="ui inverted header">Terms & Conditions</h4>
+                <div className="ui inverted link list">
+                    <NavLink className="item" routeName="license" href="/license">License</NavLink>
+                  <NavLink className="item" routeName="imprint" href="/imprint">Imprint</NavLink>
+                  <NavLink className="item" routeName="dataprotection" href="/dataprotection">Data Protection Conditions</NavLink>
+                </div>
+              </div>
+              <div className="seven wide column">
+                <p>Copyright &copy; 2017 &middot; All Rights Reserved</p>
+                <p>Build GIT_COMMIT&#64;GIT_BRANCH</p>
+              </div>
             </div>
+
+            </div>
+          </div>
         );
     }
 }

--- a/components/Home/About.js
+++ b/components/Home/About.js
@@ -3,43 +3,39 @@ import React from 'react';
 class About extends React.Component {
     render() {
         return (
-            <div className="ui container grid" ref="about">
-                <div className="ui row">
-                    <div className="column">
-                        <div className="ui content">
-                            <h2 className="ui header">About SlideWiki</h2>
-                            <p>SlideWiki aims to exploit the wisdom, creativity and productivity of the crowd for the creation of qualitative, rich,
-                                engaging educational content. With SlideWiki users can create and collaborate on slides, diagrams, assessments and arrange this
-                                content in richly-structured course presentations.</p>
-                                <p>SlideWiki empowers communities of educators to author, share and re-use sophisticated educational content in a truly collaborative way.
-                                Existing presentations can be imported and transformed into interactive courses using HTML and LaTeX.
-                                All content in SlideWiki is versioned thereby allowing users to revise, adapt and re-mix all content.
-                                Self-test questions can be attached to each individual slide and are aggregated on the presentation level into comprehensive
-                                self-assessment tests. Users can create their own presentation themes.
-                                Slidewiki supports the semi-automatic translation of courses in more than 50 languages, allowing synchronization of the content between the languages.</p>
-                                <p>With SlideWiki we aim to make educational content dramatically more accessible, interactive, engaging and qualitative.</p>
-                                <p>Slidewiki is an open-source platform, and all its content can be reused under CC-BY license. SlideWiki development, large-scale trials
-                                and underlying reseach is funded from Framework Programme for Research and Innovation Horizon 2020 under grant agreement no 688095.
-                                For more details, see <a href="http://slidewiki.eu">SlideWiki EU project website</a>
+            <div className="ui text container" ref="about">
+            <div className="ui hidden divider"></div>
+                <h2 className="ui header">About SlideWiki</h2>
+                <p>SlideWiki aims to exploit the wisdom, creativity and productivity of the crowd for the creation of qualitative, rich,
+                    engaging educational content. With SlideWiki users can create and collaborate on slides, diagrams, assessments and arrange this
+                    content in richly-structured course presentations.</p>
+                <p>SlideWiki empowers communities of educators to author, share and re-use sophisticated educational content in a truly collaborative way.
+                    Existing presentations can be imported and transformed into interactive courses using HTML and LaTeX.
+                    All content in SlideWiki is versioned thereby allowing users to revise, adapt and re-mix all content.
+                    Self-test questions can be attached to each individual slide and are aggregated on the presentation level into comprehensive
+                    self-assessment tests. Users can create their own presentation themes.
+                    Slidewiki supports the semi-automatic translation of courses in more than 50 languages, allowing synchronization of the content between the languages.</p>
+                <p>With SlideWiki we aim to make educational content dramatically more accessible, interactive, engaging and qualitative.</p>
+                <p>Slidewiki is an open-source platform, and all its content can be reused under CC-BY license. SlideWiki development, large-scale trials
+                    and underlying reseach is funded from Framework Programme for Research and Innovation Horizon 2020 under grant agreement no 688095.
+                    For more details, see <a href="http://slidewiki.eu">SlideWiki EU project website</a>
 
-                            </p>
-                            <h3> The final-release functionality of the SlideWiki platform will include, but not limited to: </h3>
-                            <ul>
-                                <li>WYSIWYG slide authoring</li>
-                                <li>Logical slide and deck representation</li>
-                                <li>LaTeX/MathML integration</li>
-                                <li>Multilingual decks / semi-automatic translation / synchronization of content between translated versions</li>
-                                <li>Import/export of the content into a number of formats (PDF, SCORM, ePUB, PowerPoint, OpenOffice and others)</li>
-                                <li>Dynamic CSS themability and transitions</li>
-                                <li>Support of social networking activities</li>
-                                <li>Full revisioning and branching of slides and decks</li>
-                                <li>E-Learning with self-assessment questionnaires</li>
-                                <li>Content recommendation and personalization</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
+                </p>
+                <h3> The final-release functionality of the SlideWiki platform will include, but not limited to: </h3>
+                <ul>
+                    <li>WYSIWYG slide authoring</li>
+                    <li>Logical slide and deck representation</li>
+                    <li>LaTeX/MathML integration</li>
+                    <li>Multilingual decks / semi-automatic translation / synchronization of content between translated versions</li>
+                    <li>Import/export of the content into a number of formats (PDF, SCORM, ePUB, PowerPoint, OpenOffice and others)</li>
+                    <li>Dynamic CSS themability and transitions</li>
+                    <li>Support of social networking activities</li>
+                    <li>Full revisioning and branching of slides and decks</li>
+                    <li>E-Learning with self-assessment questionnaires</li>
+                    <li>Content recommendation and personalization</li>
+                </ul>
             </div>
+
         );
     }
 }

--- a/components/Home/License.js
+++ b/components/Home/License.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+class license extends React.Component {
+    render() {
+        return (
+            <div className="ui text container" ref="license">
+                <div className="hidden divider"></div>
+                <h1 className="ui header">Creative Commons Licenses and SlideWiki</h1>
+                <p>SlideWiki is an open platform allowing you to publish educational content under an open, Creative Commons license. By publishing content under a Creative Commons license, SlideWiki intends to empower educational communities to author, share and reuse educational content in order to improve the availability of high-quality educational materials. This page will explain how Creative Common licenses are used by SlideWiki and answer some common questions.</p>
+<h2 className="ui header">Creative Commons Attribution ShareAlike 4.0 CC BY-SA</h2>
+                <div className="ui right floated medium image">
+                <img alt="Creative Commons BY-SA License logo"  src="http://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" />
+                </div>
+                <p>Decks and slides in SlideWiki are published under the Creative Common Attribution ShareAlike licence. This license lets others reuse, alter and build on slides work as long as they credit you and license their new creations under the identical terms. All new slides or works outside of SlideWiki based on your work will carry the same license, so any derivatives will also allow commercial use but will need to attribute your work and publish under the same license.</p>
+                <p>To find out more about the CC BY-SA and access the full license test, view the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Human readable summary of the CC-BY-SA license from Creative Commons</a>.</p>
+   <h3 className="ui header">Why do we use the CC BY-SA licence for SlideWiki decks and Slides?</h3>             
+                    <p>The CC BY-SA license is used by Wikipedia and similar resources, which means you can include material from Wikipedia in your decks as long as you include the original source. It also ensures that material created by our users is always attributed to them, which we believe enhances the quality and probity of educational resources. </p>
+                <p>By using this license, other users will be free to copy and redistribute the materials in your deck in any medium or format. They will also be able to adapt the materials, including remixing, transforming and building on the material for any purpose, including commercial activities. </p>
+      <h3 className="ui header">Can I add any materials to my slides and decks under the CC BY-SA licence?</h3>      
+                <p>When adding content to your slides, it is your responsibility to ensure that it can be shared under a Creative Commons ShareAlike license. This means that it must be possible to adapt the material and for it to be used by anyone (including in commercial activities). Materials that are in the public domain (sometimes referred to as CC0) or licenses under Creative Commons Attribution (CC BY) can be included in your slides.</p>
+      <h3 className="ui header">Where can I find material that I can use under this license in my Slides and decks?</h3>
+                <p>As all decks and slides are published under a license that allows content to be adapted and resused, you can reuse content from any decks in your own slides. The Append Deck and Append Slides function allows you to find and attach slides and decks as you are creating you are authoring your own work.</p>
+                <p><a href="https://search.creativecommons.org">Creative Commons Search</a> lists sources of materials published under  creative commons licenses. Some media services such as Flikr, YouTube and Vimeo publish some content under creative commons licenses. Content marked “All rights reserved” cannot be included in SlideWiki.</p>
+                <p>If you add content to your slides that is published under a Creative Common Attribution ShareAlike licence then you must ensure you add the attribution information into the Sources for the slide. [You can find out more about adding Sources to slides in our Guide]. Images published under a Creative Commons Attribution ShareAlike licence can be uploaded and incorporated into SlideWiki slides. However, it is your responsibility to ensure that you provide credit or attribution to the creator within the image upload dialog.</p>
+                <p> If a video or content has an Embed function provided by the video’s owner then it is possible to embed the video in your slides. However, caution should be taken with videos that could have been posted without the copyright owner’s permission and you should not copy the video, only allow videos to stream through embedding it in a slide. [You can find out more about embedding videos in slides in our Guide.]</p>
+                <p>If you would like to find out more then you made find this article <a href="https://www.theedublogger.com/2017/01/20/copyright-fair-use-and-creative-commons/">“The Educator’s Guide To Copyright, Fair Use, And Creative Commons”</a> helpful.
+</p>
+             <h2 className="ui header">Creative Commons Attribution 4.0 CC BY</h2> 
+                <div className="ui right floated medium image">
+                <img alt="Creative Commons CC BY License logo"  src="http://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png" />
+                    </div>
+                <p>This license allows materials to by copy and redistributed in any medium or format as long as they are attributed to the original creator and copyright notices. Images published under a Creative Commons Attribution licence can be uploaded and incorporated into SlideWiki slides. However, it is your responsibility to ensure that you provide credit or attribution to the creator within the image upload dialog.</p>
+                <p>To find out more about the CC BY and access the full license test, view the <a href="https://creativecommons.org/licenses/by/4.0/">Human readable summary of the CC BY license from Creative Commons</a>.</p>
+                <h2 className="ui header">Work in the Public Domain, free of copyright or CC0</h2> 
+                <div className="ui right floated medium image">
+                <img alt="Creative Commons CC 0 public domain License logo"  src="http://mirrors.creativecommons.org/presskit/buttons/88x31/png/cc-zero.png" />
+                </div>
+                <p>Work in the Public domain is free of copyright restrictions. This is usually for works that are not copyrightable, their copyright has expired or the creator has assigned their work to the public domain. While it is not always necessary to attribute the source of public domain work, it is good practice to attribute works to the creator or source to add providence to your slides. CCO is the Creative Commons license to enable authors and creators to waive their interests in the their work and place it in the public domain. </p>
+                <h2 className="ui header">Notices</h2>
+                <p>No warranties are given on this information. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material. We reserve the right to remove materials and content from the SlideWiki platform that we believe to infringe copyright and license requirements.                </p>
+            </div>
+
+        );
+    }
+}
+
+export default license;

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -98,6 +98,19 @@ export default {
             done();
         }
     },
+     license: {
+        path: '/license',
+        method: 'get',
+        page: 'license',
+        title: 'SlideWiki -- Content licenses',
+        handler: require('../components/Home/License'),
+        action: (context, payload, done) => {
+            context.dispatch('UPDATE_PAGE_TITLE', {
+                pageTitle: shortTitle + ' | Content Licenses'
+            });
+            done();
+        }
+    },
     imprint: {
         path: '/imprint',
         method: 'get',

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -98,7 +98,7 @@ export default {
             done();
         }
     },
-     license: {
+    license: {
         path: '/license',
         method: 'get',
         page: 'license',


### PR DESCRIPTION
This adds a page describing the Creative Common license used in SW. Available at /license 
It also merges the updated footer layout.