### PR TITLE
BugFix: Swik 1599 fix download with a dialog

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -16,7 +16,7 @@ import incrementDeckViewCounter from '../../../../actions/activityfeed/increment
 import dislikeActivity from '../../../../actions/activityfeed/dislikeActivity.js';
 import UserProfileStore from '../../../../stores/UserProfileStore';
 import ContentLikeStore from '../../../../stores/ContentLikeStore';
-import DownloadButton from './DownloadButton';
+import DownloadModal from './DownloadModal';
 
 class ContentActionsFooter extends React.Component {
     constructor(props) {
@@ -166,7 +166,7 @@ class ContentActionsFooter extends React.Component {
                                 <i className="print large icon"></i>
                             </button>
                             </NavLink>
-                            <DownloadButton/>
+                            <DownloadModal/>
                             <ReportModal/>
                             <SocialShare userid={this.props.UserProfileStore.userid} selector={this.props.ContentStore.selector} />
                             <button className={likeButton} type="button" aria-label="Like" data-tooltip={tooltipLikeButton} onClick={this.handleLikeClick.bind(this)}>

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -180,7 +180,7 @@ class DownloadModal extends React.Component{
                                    </Grid.Column>
 
                                    <Grid.Column textAlign='left' width={13} role="radiogroup" aria-labelledby="downloadModalDescription">
-                                    <label  id="downloadModalDescription" tabIndex='0'>{this.context.intl.formatMessage(this.messages.downloadModal_description)}</label>
+                                    <div  id="downloadModalDescription" tabIndex='0'>{this.context.intl.formatMessage(this.messages.downloadModal_description)}</div>
                                     <Form.Field >
                                           <Radio
                                             label='PDF'

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import FocusTrap from 'focus-trap-react';
+import { Button, Container, Form, Modal, TextArea, Icon, Segment } from 'semantic-ui-react';
+const headerStyle = {
+    'textAlign': 'center'
+};
+
+class DownloadModal extends React.Component{
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            modalOpen: false,
+            activeTrap: false,
+
+        };
+
+        this.handleOpen = this.handleOpen.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.unmountTrap = this.unmountTrap.bind(this);
+        this.handleDownload = this.handleDownload.bind(this);
+    }
+
+    handleOpen(){
+        $('#app').attr('aria-hidden', 'true');
+        this.setState({
+            modalOpen:true,
+            activeTrap:true
+        });
+
+    }
+
+
+    handleClose(){
+        $('#app').attr('aria-hidden', 'false');
+        this.setState({
+            modalOpen: false,
+            activeTrap: false
+        });
+
+    }
+    unmountTrap() {
+        if(this.state.activeTrap){
+            this.setState({ activeTrap: false });
+            $('#app').attr('aria-hidden','false');
+        }
+    }
+    handleDownload(){
+
+    }
+    render() {
+        return(
+
+              <Modal
+                  trigger={
+                        <Button icon aria-hidden="false" className="ui button" type="button" aria-label="Download" data-tooltip="Download" onClick={this.handleOpen} >
+                              <Icon name='download' size='large'/>
+                        </Button>
+
+                      }
+                  open={this.state.modalOpen}
+                  onOpen={this.handleOpen}
+                  onClose={this.handleClose}
+                  id="downloadModal"
+                  aria-labelledby="downloadModalHeader"
+                  aria-describedby="downloadModalDescription"
+                  tabIndex="0"
+              >
+                  <FocusTrap
+                      id="focus-trap-downloadModal"
+                      className = "header"
+                      active={this.state.activeTrap}
+                      onDeactivate={this.unmountTrap}
+                      clickOutsideDeactivates={true}
+                      initialFocus=""
+                  >
+                      <Modal.Header className="ui center aligned" id="downloadModalHeader">
+                          <h1 style={headerStyle}>Download this deck</h1>
+                      </Modal.Header>
+                      <Modal.Content>
+                          <Container>
+                              <Segment color="blue" textAlign="center" padded>
+                                 <Segment>
+                                     <div className="sr-only" id="downloadModalDescription">Select one target format to download this deck</div>
+                                  <Form id="downloadForm">
+
+                                      <Button
+                                          color="blue"
+                                          type="submit"
+                                          content="Download"
+                                          icon='download'
+                                          onClick={this.handleDownload}
+                                      />
+                                      <Button
+                                          icon="remove"
+                                          color="red"
+                                          type="button"
+                                          onClick={this.handleClose}
+                                          content="Cancel"
+                                      />
+
+                                  </Form>
+                                  </Segment>
+                              </Segment>
+                          </Container>
+
+                      </Modal.Content>
+
+                  </FocusTrap>
+              </Modal>
+
+        );
+
+    }
+
+
+}
+DownloadModal.contextTypes = {
+    executeAction: React.PropTypes.func.isRequired
+};
+
+export default DownloadModal;

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import FocusTrap from 'focus-trap-react';
-import { Button, Container, Form, Modal, TextArea, Icon, Segment } from 'semantic-ui-react';
-const headerStyle = {
-    'textAlign': 'center'
-};
+import { Button, Container, Form, Modal, Radio, Icon, Segment, Grid } from 'semantic-ui-react';
+import {connectToStores} from 'fluxible-addons-react';
+import ContentStore from '../../../../stores/ContentStore';
+import UserProfileStore from '../../../../stores/UserProfileStore';
+import {Microservices} from '../../../../configs/microservices';
+import addActivity from '../../../../actions/activityfeed/addActivity';
+import incrementDeckViewCounter from '../../../../actions/activityfeed/incrementDeckViewCounter';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
 
 class DownloadModal extends React.Component{
     constructor(props) {
@@ -12,6 +17,7 @@ class DownloadModal extends React.Component{
         this.state = {
             modalOpen: false,
             activeTrap: false,
+            radioValue: 'PDF'
 
         };
 
@@ -19,6 +25,27 @@ class DownloadModal extends React.Component{
         this.handleClose = this.handleClose.bind(this);
         this.unmountTrap = this.unmountTrap.bind(this);
         this.handleDownload = this.handleDownload.bind(this);
+        this.handleRadioChange = this.handleRadioChange.bind(this);
+
+
+        this.messages = defineMessages({
+            downloadModal_header:{
+                id: 'downloadModal.downloadModal_header',
+                defaultMessage:'Download this deck'
+            },
+            downloadModal_description:{
+                id: 'downloadModal.downloadModal_description',
+                defaultMessage:'Select the download file format:'
+            },
+            downloadModal_downloadButton:{
+                id:'downloadModal.downloadModal_downloadButton',
+                defaultMessage: 'Download'
+            },
+            downloadModal_cancelButton:{
+                id:'downloadModal.downloadModal_cancelButton',
+                defaultMessage: 'Cancel'
+            }
+        });
     }
 
     handleOpen(){
@@ -45,9 +72,69 @@ class DownloadModal extends React.Component{
             $('#app').attr('aria-hidden','false');
         }
     }
-    handleDownload(){
+    handleRadioChange(event,data){
+        this.setState({
+            radioValue:data.value
+        });
 
     }
+    getExportHref(type){
+        let splittedId;
+        if (this.props.ContentStore.selector.id !== undefined && this.props.ContentStore.selector.id !== '' && this.props.ContentStore.selector.id !== 0){
+
+            splittedId =  this.props.ContentStore.selector.id.split('-'); //separates deckId and revision
+        } else {
+            return ''; //no deckId
+        }
+
+        switch (type) {
+            case 'PDF':
+                return Microservices.pdf.uri + '/exportPDF/' + splittedId[0];
+                break;
+            case 'ePub':
+                return Microservices.pdf.uri + '/exportEPub/' + splittedId[0];
+                break;
+            case 'SCORMv1.2':
+            case 'SCORMv2':
+            case 'SCORMv3':
+            case 'SCORMv4':
+                let version = type.split('v'); //separates format from version. In second position we have the version
+                return Microservices.pdf.uri + '/exportSCORM/' + splittedId[0]+ '?version='+version[1];
+                break;
+            default:
+                return '';
+
+        }
+
+
+    }
+    createDownloadActivity() {
+        //create new activity
+        let splittedId =  this.props.ContentStore.selector.id.split('-'); //separates deckId and revision
+        let userId = String(this.props.UserProfileStore.userid);
+        if (userId === '') {
+            userId = '0';//Unknown - not logged in
+        }
+        let activity = {
+            activity_type: 'download',
+            user_id: userId,
+            content_id: splittedId[0],
+            content_kind: 'deck'
+        };
+        this.context.executeAction(addActivity, {activity: activity});
+        context.executeAction(incrementDeckViewCounter, {type: 'download'});
+    }
+    handleDownload(event,data){
+        if(process.env.BROWSER){
+            event.preventDefault();
+            window.open(this.getExportHref(this.state.radioValue));
+        }
+
+        this.createDownloadActivity();
+
+
+    }
+
     render() {
         return(
 
@@ -59,35 +146,126 @@ class DownloadModal extends React.Component{
 
                       }
                   open={this.state.modalOpen}
-                  onOpen={this.handleOpen}
                   onClose={this.handleClose}
                   id="downloadModal"
                   aria-labelledby="downloadModalHeader"
                   aria-describedby="downloadModalDescription"
+                  aria-hidden = {!this.state.modalOpen}
                   tabIndex="0"
               >
                   <FocusTrap
                       id="focus-trap-downloadModal"
                       className = "header"
                       active={this.state.activeTrap}
-                      onDeactivate={this.unmountTrap}
-                      clickOutsideDeactivates={true}
-                      initialFocus=""
+                      focusTrapOptions={{
+                          onDeactivate: this.unmountTrap,
+                          clickOutsideDeactivates: true ,
+                          initialFocus: '#downloadModalDescription'
+                      }}
                   >
                       <Modal.Header className="ui center aligned" id="downloadModalHeader">
-                          <h1 style={headerStyle}>Download this deck</h1>
+                          <h1 style={{'textAlign': 'center'}}> {this.context.intl.formatMessage(this.messages.downloadModal_header)}</h1>
                       </Modal.Header>
                       <Modal.Content>
                           <Container>
                               <Segment color="blue" textAlign="center" padded>
-                                 <Segment>
-                                     <div className="sr-only" id="downloadModalDescription">Select one target format to download this deck</div>
-                                  <Form id="downloadForm">
+                                <Segment>
+                                  <Form id="downloadForm" >
+                                   <Grid >
+                                   <Grid.Row>
 
+                                   <Grid.Column width={3}>
+
+                                   </Grid.Column>
+
+                                   <Grid.Column textAlign='left' width={13} role="radiogroup">
+                                    <label  id="downloadModalDescription" >{this.context.intl.formatMessage(this.messages.downloadModal_description)}</label>
+                                    <Form.Field >
+                                          <Radio
+                                            label='PDF'
+                                            name='downloadRadioGroup'
+                                            value='PDF'
+                                            checked={this.state.radioValue === 'PDF'}
+                                            onChange={this.handleRadioChange}
+                                            role="radio"
+                                            aria-checked={this.state.radioValue === 'PDF'}
+                                            tabIndex="0"
+                                            />
+                                        </Form.Field>
+                                        <Form.Field>
+                                          <Radio
+                                              label='ePub'
+                                              name='downloadRadioGroup'
+                                              value='ePub'
+                                              checked={this.state.radioValue === 'ePub'}
+                                              onChange={this.handleRadioChange}
+                                              role="radio"
+                                              aria-checked={this.state.radioValue === 'ePub'}
+                                              tabIndex="-1"
+
+                                          />
+                                         </Form.Field>
+                                         <Form.Field>
+                                           <Radio
+                                               label='SCORM 1.2'
+                                               name='downloadRadioGroup'
+                                               value='SCORMv1.2'
+                                               checked={this.state.radioValue === 'SCORMv1.2'}
+                                               onChange={this.handleRadioChange}
+                                               role="radio"
+                                               aria-checked={this.state.radioValue === 'SCORMv1.2'}
+                                               tabIndex="-1"
+
+                                           />
+                                          </Form.Field>
+                                          <Form.Field>
+                                            <Radio
+                                                label='SCORM 2004 (3rd edition)'
+                                                name='downloadRadioGroup'
+                                                value='SCORMv2'
+                                                checked={this.state.radioValue === 'SCORMv2'}
+                                                onChange={this.handleRadioChange}
+                                                role="radio"
+                                                aria-checked={this.state.radioValue === 'SCORMv2'}
+                                                tabIndex="-1"
+
+                                            />
+                                          </Form.Field>
+                                          <Form.Field>
+                                            <Radio
+                                                label='SCORM 2004 (4th edition)'
+                                                name='downloadRadioGroup'
+                                                value='SCORMv3'
+                                                checked={this.state.radioValue === 'SCORMv3'}
+                                                onChange={this.handleRadioChange}
+                                                role="radio"
+                                                tabIndex="-1"
+                                            />
+                                          </Form.Field>
+                                          <Form.Field>
+                                            <Radio
+                                                label='SCORM 2004 (5th edition)'
+                                                name='downloadRadioGroup'
+                                                value='SCORMv4'
+                                                checked={this.state.radioValue === 'SCORMv4'}
+                                                onChange={this.handleRadioChange}
+                                                role="radio"
+                                                aria-checked={this.state.radioValue === 'SCORMv4'}
+                                                tabIndex="-1"
+                                            />
+                                          </Form.Field>
+
+                                      </Grid.Column>
+                                      <Grid.Column>
+                                      </Grid.Column>
+                                      </Grid.Row>
+                                      <Grid.Row>
+
+                                      <Grid.Column width={16} textAlign='center'>
                                       <Button
                                           color="blue"
                                           type="submit"
-                                          content="Download"
+                                          content={this.context.intl.formatMessage(this.messages.downloadModal_downloadButton)}
                                           icon='download'
                                           onClick={this.handleDownload}
                                       />
@@ -96,11 +274,17 @@ class DownloadModal extends React.Component{
                                           color="red"
                                           type="button"
                                           onClick={this.handleClose}
-                                          content="Cancel"
+                                          content={this.context.intl.formatMessage(this.messages.downloadModal_downloadButton)}
                                       />
+                                      </Grid.Column>
+                                      </Grid.Row>
+
+                                      </Grid>
 
                                   </Form>
-                                  </Segment>
+
+
+                                </Segment>
                               </Segment>
                           </Container>
 
@@ -115,8 +299,16 @@ class DownloadModal extends React.Component{
 
 
 }
+
 DownloadModal.contextTypes = {
-    executeAction: React.PropTypes.func.isRequired
+    executeAction: React.PropTypes.func.isRequired,
+    intl: React.PropTypes.object.isRequired
 };
+DownloadModal = connectToStores(DownloadModal,[ContentStore,UserProfileStore],(context,props) => {
+    return{
+        ContentStore : context.getStore(ContentStore).getState(),
+        UserProfileStore : context.getStore(UserProfileStore).getState()
+    };
+});
 
 export default DownloadModal;

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -274,7 +274,7 @@ class DownloadModal extends React.Component{
                                           color="red"
                                           type="button"
                                           onClick={this.handleClose}
-                                          content={this.context.intl.formatMessage(this.messages.downloadModal_downloadButton)}
+                                          content={this.context.intl.formatMessage(this.messages.downloadModal_cancelButton)}
                                       />
                                       </Grid.Column>
                                       </Grid.Row>

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -151,6 +151,7 @@ class DownloadModal extends React.Component{
                   aria-labelledby="downloadModalHeader"
                   aria-describedby="downloadModalDescription"
                   aria-hidden = {!this.state.modalOpen}
+                  role="dialog"
                   tabIndex="0"
               >
                   <FocusTrap

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -178,7 +178,7 @@ class DownloadModal extends React.Component{
 
                                    </Grid.Column>
 
-                                   <Grid.Column textAlign='left' width={13} role="radiogroup" >
+                                   <Grid.Column textAlign='left' width={13} role="radiogroup" aria-labelledby="downloadModalDescription">
                                     <label  id="downloadModalDescription" tabIndex='0'>{this.context.intl.formatMessage(this.messages.downloadModal_description)}</label>
                                     <Form.Field >
                                           <Radio
@@ -189,7 +189,9 @@ class DownloadModal extends React.Component{
                                             onChange={this.handleRadioChange}
                                             role="radio"
                                             aria-checked={this.state.radioValue === 'PDF'}
+                                            aria-label='PDF'
                                             tabIndex="0"
+
                                             />
                                         </Form.Field>
                                         <Form.Field>
@@ -201,6 +203,7 @@ class DownloadModal extends React.Component{
                                               onChange={this.handleRadioChange}
                                               role="radio"
                                               aria-checked={this.state.radioValue === 'ePub'}
+                                              aria-label='ePub'
                                               tabIndex="-1"
 
                                           />
@@ -214,6 +217,7 @@ class DownloadModal extends React.Component{
                                                onChange={this.handleRadioChange}
                                                role="radio"
                                                aria-checked={this.state.radioValue === 'SCORMv1.2'}
+                                               aria-label='SCORM 1.2'
                                                tabIndex="-1"
 
                                            />
@@ -227,6 +231,7 @@ class DownloadModal extends React.Component{
                                                 onChange={this.handleRadioChange}
                                                 role="radio"
                                                 aria-checked={this.state.radioValue === 'SCORMv2'}
+                                                aria-label='SCORM 2004 (3rd edition)'
                                                 tabIndex="-1"
 
                                             />
@@ -239,7 +244,8 @@ class DownloadModal extends React.Component{
                                                 checked={this.state.radioValue === 'SCORMv3'}
                                                 onChange={this.handleRadioChange}
                                                 role="radio"
-                                                  aria-checked={this.state.radioValue === 'SCORMv3'}
+                                                aria-checked={this.state.radioValue === 'SCORMv3'}
+                                                aria-label='SCORM 2004 (4th edition)'
                                                 tabIndex="-1"
                                             />
                                           </Form.Field>
@@ -252,6 +258,7 @@ class DownloadModal extends React.Component{
                                                 onChange={this.handleRadioChange}
                                                 role="radio"
                                                 aria-checked={this.state.radioValue === 'SCORMv4'}
+                                                aria-label='SCORM 2004 (5th edition)'
                                                 tabIndex="-1"
                                             />
                                           </Form.Field>

--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -143,8 +143,8 @@ class DownloadModal extends React.Component{
                         <Button icon aria-hidden="false" className="ui button" type="button" aria-label="Download" data-tooltip="Download" onClick={this.handleOpen} >
                               <Icon name='download' size='large'/>
                         </Button>
+                  }
 
-                      }
                   open={this.state.modalOpen}
                   onClose={this.handleClose}
                   id="downloadModal"
@@ -178,8 +178,8 @@ class DownloadModal extends React.Component{
 
                                    </Grid.Column>
 
-                                   <Grid.Column textAlign='left' width={13} role="radiogroup">
-                                    <label  id="downloadModalDescription" >{this.context.intl.formatMessage(this.messages.downloadModal_description)}</label>
+                                   <Grid.Column textAlign='left' width={13} role="radiogroup" >
+                                    <label  id="downloadModalDescription" tabIndex='0'>{this.context.intl.formatMessage(this.messages.downloadModal_description)}</label>
                                     <Form.Field >
                                           <Radio
                                             label='PDF'
@@ -239,6 +239,7 @@ class DownloadModal extends React.Component{
                                                 checked={this.state.radioValue === 'SCORMv3'}
                                                 onChange={this.handleRadioChange}
                                                 role="radio"
+                                                  aria-checked={this.state.radioValue === 'SCORMv3'}
                                                 tabIndex="-1"
                                             />
                                           </Form.Field>


### PR DESCRIPTION
Download button opens a dialog in which users can select the file format to download, and then the user can click on "download"  or on "cancel" to discard the action.

With this new interface, the bug instroduced by the download button is erased.

It also uses intl to translate the sentences, except the name of the formats. 