### PR TITLE
Support sending JWT token when posting user activities

### DIFF
--- a/actions/activityfeed/addActivities.js
+++ b/actions/activityfeed/addActivities.js
@@ -1,8 +1,13 @@
+import UserProfileStore from '../../stores/UserProfileStore';
 import serviceUnavailable from '../error/serviceUnavailable';
 const log = require('../log/clog');
 
 export default function addActivities(context, payload, done) {
     log.info(context);
+
+    //enrich with jwt
+    payload.jwt = context.getStore(UserProfileStore).jwt;
+
     context.service.create('activities.newarray', payload, {timeout: 20 * 1000}, (err, res) => {
         if (err) {
             log.error(context, {filepath: __filename});

--- a/actions/activityfeed/addActivity.js
+++ b/actions/activityfeed/addActivity.js
@@ -1,8 +1,13 @@
+import UserProfileStore from '../../stores/UserProfileStore';
 import serviceUnavailable from '../error/serviceUnavailable';
 const log = require('../log/clog');
 
 export default function addActivity(context, payload, done) {
     log.info(context);
+
+    //enrich with jwt
+    payload.jwt = context.getStore(UserProfileStore).jwt;
+
     context.service.create('activities.new', payload, {timeout: 20 * 1000}, (err, res) => {
         if (err) {
             log.error(context, {filepath: __filename});

--- a/services/activities.js
+++ b/services/activities.js
@@ -52,11 +52,15 @@ export default {
         log.info({Id: req.reqId, Service: __filename.split('/').pop(), Resource: resource, Operation: 'read', Method: req.method});
         let args = params.params? params.params : params;
 
+        let headers = {};
+        if (args.jwt) headers['----jwt----'] = args.jwt;
+
         switch (resource) {
             case 'activities.new':
                 rp.post({
                     uri: Microservices.activities.uri + '/activity/new',
-                    body: JSON.stringify(args.activity)
+                    body: JSON.stringify(args.activity),
+                    headers,
                 }).then((res) => {
                     callback(null, {activity: JSON.parse(res)});
                 }).catch((err) => {
@@ -67,7 +71,8 @@ export default {
             case 'activities.newarray':
                 rp.post({
                     uri: Microservices.activities.uri + '/activities/new',
-                    body: JSON.stringify(args.activities)
+                    body: JSON.stringify(args.activities),
+                    headers,
                 }).then((res) => {
                     callback(null, {activities: JSON.parse(res)});
                 }).catch((err) => {


### PR DESCRIPTION
This completes work related to securing the activities- and xapi-services with jwt and including the email in the jwt token so that it can be safely and efficiently used in the xapi-service to properly write user activities in the learning locker.