### PR TITLE
Added a custom HTML template for the presentation rooms feature

### DIFF
--- a/components/PresentationRoomsHTMLLayout.js
+++ b/components/PresentationRoomsHTMLLayout.js
@@ -37,6 +37,7 @@ class PresentationRoomsHTMLLayout extends React.Component {
                 {/*TODO Following custom libs have been included due to the header bar (that is included but will be removed internally) --> Don't load the headerbar at all and remove the following two libs*/}
                 <script src="/custom_modules/custom-semantic-ui/dist/components/search.min.js" defer></script>
                 <script src="/custom_modules/custom-semantic-ui/dist/components/sidebar.min.js" defer></script>
+                <script src="/custom_modules/custom-semantic-ui/dist/components/dropdown.min.js" defer></script>
                 <script dangerouslySetInnerHTML={{__html: this.props.state}}></script>
                 <script src="/jquery/dist/jquery.min.js"></script>
                 {/* All external vendors bundle*/

--- a/components/PresentationRoomsHTMLLayout.js
+++ b/components/PresentationRoomsHTMLLayout.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import ApplicationStore from '../stores/ApplicationStore';
+import ga from '../plugins/googleAnalytics/ga';
+import { Microservices } from '../configs/microservices';
+
+let hook = require('css-modules-require-hook');
+
+hook({
+    generateScopedName: '[hash:base64:5]',
+});
+
+class PresentationRoomsHTMLLayout extends React.Component {
+    render() {
+        let user = this.props.context.getUser();
+        return (
+            <html lang={ this.props.lang }>
+            <head>
+                <meta charSet="utf-8" />
+                <title>{this.props.context.getStore(ApplicationStore).getPageTitle()}</title>
+                <meta name="viewport" content="width=device-width, user-scalable=no" />
+                <link href="/custom_modules/custom-semantic-ui/dist/semantic.min.css" rel="stylesheet" type="text/css" />
+                <link href="/assets/css/custom.css" rel="stylesheet" type="text/css" />
+                <link href="/sweetalert2/dist/sweetalert2.min.css" rel="stylesheet" type="text/css" />
+                {/* Vendors css bundle */
+                    this.props.addAssets ? <link href="/public/css/vendor.bundle.css" rel="stylesheet" type="text/css" />: <style></style>
+                }
+            </head>
+            <body>
+                <div id="app" aria-hidden="false" dangerouslySetInnerHTML={{__html: this.props.markup}}></div>
+                {/* Following are added only to support IE browser */}
+                <script src="/es5-shim/es5-shim.min.js"></script>
+                <script src="/es5-shim/es5-sham.min.js"></script>
+                <script src="/json3/lib/json3.min.js"></script>
+                <script src="/es6-shim/es6-shim.min.js"></script>
+                <script src="/es6-shim/es6-sham.min.js"></script>
+                {/* Above are added only to support IE browser */}
+                {/*TODO Following custom libs have been included due to the header bar (that is included but will be removed internally) --> Don't load the headerbar at all and remove the following two libs*/}
+                <script src="/custom_modules/custom-semantic-ui/dist/components/search.min.js" defer></script>
+                <script src="/custom_modules/custom-semantic-ui/dist/components/sidebar.min.js" defer></script>
+                <script dangerouslySetInnerHTML={{__html: this.props.state}}></script>
+                <script src="/jquery/dist/jquery.min.js"></script>
+                {/* All external vendors bundle*/
+                    this.props.addAssets ? <script src={'/public/js/vendor.bundle.js'} defer></script> : ''
+                }
+                <script src={ Microservices.webrtc.uri + '/socket.io/socket.io.js' }></script>
+                <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
+                {/* Main app bundle */}
+                <script src={'/public/js/' + this.props.clientFile} defer></script>
+                <script src="/sweetalert2/dist/sweetalert2.min.js" defer></script>
+                <script dangerouslySetInnerHTML={ {__html: ga} } />
+            </body>
+            </html>
+        );
+    }
+}
+
+export default PresentationRoomsHTMLLayout;

--- a/server/handleServerRendering.js
+++ b/server/handleServerRendering.js
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom/server';
 import app from '../app';
 import HTMLComponent from '../components/DefaultHTMLLayout';
 import PresentorComponent from '../components/PresentorHTMLLayout';
+import PresentationRoomsComponent from '../components/PresentationRoomsHTMLLayout';
 
 import serialize from 'serialize-javascript';
 import debugLib from 'debug';
@@ -43,6 +44,9 @@ let renderApp = function(req, res, context){
     let layout = HTMLComponent;
     if(req.url && req.url.slice(0,20).includes('/Presentation/')){//NOTE only test first few chars as presentaton rooms URL has "/Presentation/..." also in it
         layout = PresentorComponent;
+    }
+    if(req.url && req.url.includes('/presentationbroadcast')){
+        layout = PresentationRoomsComponent;
     }
     const htmlElement = React.createElement(layout, {
         //clientFile: env === 'production' ? 'main.min.js' : 'main.js',


### PR DESCRIPTION
I've added a custom HTML template for the presentation rooms feature, just like we did for the presentation mode. I've replicated the introduced changes for the presentation mode and removed a lot of unnecessary JS libs and CSS libs, that are not needed for presentation rooms feature. 

This shrinks the size of the application (that initially must be downloaded) and the DOM size a lot. It also decreases initial load time of the page, as the browser does not need to evaluate so much libraries anymore.

Please verify that everything is still displayed correctly (as I removed some CSS libs) and verify that everything still works, without throwing any errors on the browser console (as I removed a lot of JS libs).