### PR TITLE
SWIK-1106 Visual Deck Tree

### DIFF
--- a/components/Deck/TreePanel/TreeNode.js
+++ b/components/Deck/TreePanel/TreeNode.js
@@ -13,6 +13,7 @@ import AttachSlides from '../ContentPanel/AttachSubdeck/AttachSlidesModal';
 import {connectToStores} from 'fluxible-addons-react';
 import ContentStore from '../../../stores/ContentStore';
 import {Button, Popup, Icon} from 'semantic-ui-react';
+import {Microservices} from '../../../configs/microservices';
 
 
 const findAllDescendants = (node) => Immutable.Set.of(node).union(node.get('children') ? node.get('children').flatMap(findAllDescendants) : Immutable.List());
@@ -224,7 +225,24 @@ class TreeNode extends React.Component {
             </div>
         );*/
         //change the node title style if it is selected
-        const nodeTitle = cheerio.load(this.props.item.get('title')).text();
+        let iconClass = classNames({
+            'ui icon': true,
+            'huge': true,
+            'yellow folder link': true,
+            'open': this.props.item.get('expanded')
+        });
+        let imgClass = {
+            'border': (this.props.item.get('selected')) ? '1px solid blue' : '1px solid black',
+            'border-radius': '5px',
+            'margin-left': 'auto',
+            'margin-right': 'auto',
+            'display': 'block',
+            'width': '80%'
+        };
+        let img = <div style={imgClass}><img src={Microservices.file.uri+'/thumbnail/slide/'+this.props.item.get('id')+'/default'} width='90%' style={{'margin-left': 'auto', 'margin-right': 'auto', 'display': 'block'}}/></div>;
+        if (this.props.item.get('type') === 'deck') img = cheerio.load(this.props.item.get('title')).text();
+        let nodeTitle = img;
+        //let nodeTitle = <div> {img} <div style={{'text-align': 'center'}}>{cheerio.load(this.props.item.get('title')).text()}</div></div>;
         let nodeTitleDIV = nodeTitle;
         if (this.props.item.get('selected')) {
             nodeTitleDIV = <strong> {nodeTitle} </strong>;
@@ -235,16 +253,11 @@ class TreeNode extends React.Component {
                              onChange={this.handleNameChange} onKeyDown={this.handleKeyDown.bind(this, nodeSelector)}/>;
             //actionSignifier = '';
         } else {
-            nodeDIV = <NavLink href={nodeURL} tabIndex={this.props.item.get('focused') ? 0 : -1} ref={(el) => { this.nodeLink = el; }} onDoubleClick={this.handleRenameClick.bind(this, nodeSelector)} >
-                {nodeTitleDIV}</NavLink>;
+            let tmp = (this.props.item.get('type') === 'deck') ? <i onClick={this.handleExpandIconClick.bind(this, nodeSelector)} className={iconClass} aria-hidden="true" /> : '';
+            nodeDIV = <h3>{tmp}<NavLink href={nodeURL} tabIndex={this.props.item.get('focused') ? 0 : -1} ref={(el) => { this.nodeLink = el; }} onDoubleClick={this.handleRenameClick.bind(this, nodeSelector)} >
+                {nodeTitleDIV}</NavLink>{(this.props.item.get('type') === 'deck') ? <div className="ui fitted divider"/> : ''}</h3>;
         }
         //change the node icon based on the type of node and its expanded state
-        let iconClass = classNames({
-            'ui icon': true,
-            'grey file text': (this.props.item.get('type') === 'slide'),
-            'yellow folder link': (this.props.item.get('type') === 'deck'),
-            'open': this.props.item.get('expanded')
-        });
         //hide focused outline
         let compStyle = {
             outline: 'none',
@@ -257,7 +270,6 @@ class TreeNode extends React.Component {
                 {nodeIndex === 0 ? <TreeNodeTarget parentNode={self.props.parentNode} nodeIndex={nodeIndex}
                                                onMoveNode={self.props.onMoveNode} isAfterNode={false}/> : null }
                 <div onMouseOver={this.handleMouseOver.bind(this)} onMouseOut={this.handleMouseOut.bind(this)}>
-                    <i onClick={this.handleExpandIconClick.bind(this, nodeSelector)} className={iconClass} aria-hidden="true">  </i>
                     {nodeDIV}
                     {/*(this.props.username === '' || !this.props.permissions.edit || this.props.permissions.readOnly) ? '' : actionSignifier*/}
                 </div>


### PR DESCRIPTION
I've implemented a version of a visual deck tree that orientates at @abijames mockups.
Can you please review that the deck trees specific functionalities are still usable and that this matches your envisioned style?

I am currently not able to implement the accordion approach without the help of the people that implemented the deck-tree in the first place. I also recommend to refactor the deck-tree components to ease them and to get rid of unused functionality.