### PR TITLE
SWIK-2036-fixDeleteButton deletebutton: same condition to disable and…

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
@@ -264,7 +264,7 @@ class ContentActionsHeader extends React.Component {
                                 type="button"
                                 aria-label={this.context.intl.formatMessage(this.messages.deleteAriaText)}
                                 data-tooltip={this.context.intl.formatMessage(this.messages.deleteAriaText)}
-                                tabIndex={this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit || contentDetails.mode ==='edit'?-1:0}>
+                                tabIndex={contentDetails.selector.id === contentDetails.selector.sid || this.props.PermissionsStore.permissions.readOnly || !this.props.PermissionsStore.permissions.edit || contentDetails.mode ==='edit'?-1:0}>
                                 <i className="red large trash icon"></i>
                             </button>
                             {/*


### PR DESCRIPTION
… tabindex -1

The condition checked to asign -1 to the tbaIndex of the delete button is now exactly the same used to disable the button. Thus, I hope the problem was fixed now. 