### PR TITLE
SWIK-1982 Show mobile header on any screen where the user menu can't be shown due to the width of the browser

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -104,59 +104,59 @@ class Header extends React.Component {
 
         return (
             <div>
-            {cookieBanner}
-              <MediaQuery minDeviceWidth={768} values={{deviceWidth: 1600}}>
-                <div className="ui inverted blue menu" ref="header" style={{borderRadius: '0px'}}>
-                    <div className="ui fluid container">
-                        <a className="item" href='/'>
-                            <img  src="/assets/images/slideWiki-logo-linear.png" alt="SlideWiki" style={{width: '200px'}}/>
-                        </a>
-                        <div className="item">
+                {cookieBanner}
+                <MediaQuery minWidth={768} values={{deviceWidth: 1600}}>
+                    <div className="ui inverted blue menu" ref="header" style={{borderRadius: '0px'}}>
+                        <div className="ui fluid container">
+                            <a className="item" href='/'>
+                                <img  src="/assets/images/slideWiki-logo-linear.png" alt="SlideWiki" style={{width: '200px'}}/>
+                            </a>
+                            <div className="item">
+                                <SearchBox className="item"/>
+                            </div>
+                            <div className="ui right inverted blue menu">
+                                <div className="item">
+                                  <NavLink routeName="addDeck" activeClass="active" className="ui right labeled icon button" role="button">
+                                      <i className="right plus icon"></i>
+                                      <FormattedMessage id='header.addDeck' defaultMessage='Add deck'/>
+                                  </NavLink>
+                                </div>
+                                {notification_locale}
+                                <div className="item">{loginButton}<LoginModal errorMessage={this.props.UserProfileStore.errorMessage} socialLoginError={this.props.UserProfileStore.socialLoginError} userid={this.props.UserProfileStore.userid} username={this.props.UserProfileStore.username}/></div>
+                            </div>
+                        </div>
+                    </div>
+                </MediaQuery>
+                <MediaQuery maxWidth={767}>
+                    <div className="ui inverted blue menu" style={{borderRadius: '0px'}} ref="header">
+                        <button className="ui icon button item" onClick={this.toggleSidebar.bind(this)}><i className="content icon"/></button>
+                        <div className="ui right inverted blue menu">
+                            <NavLink className="item" href='/'>
+                                <i className="home icon"/><FormattedMessage id='header.slidewiki' defaultMessage='SlideWiki'/>
+                            </NavLink>
+                        </div>
+                    </div>
+                    <div className="ui inverted left dimmed sidebar vertical menu menubar" ref="menubar" onClick={this.closeSidebar.bind(this)}>
+                        <NavLink className="item" href='/'>
+                            <i className="home icon"/><FormattedMessage id='header.menu.homepage' defaultMessage='Homepage'/>
+                        </NavLink>
+                        <NavLink className="item" routeName="addDeck">
+                            <i className="add icon"/><FormattedMessage id='header.menu.addDeck' defaultMessage='Add Deck'/>
+                        </NavLink>
+                        <div className="item" onClick={this.toggleLanguageBar.bind(this)}>
+                            <i className="caret right icon"/>
+                            <LocaleSwitcher mode="headeronly"/>
+                        </div>
+                        {mobileLoginButton}
+                        <LoginModal errorMessage={this.props.UserProfileStore.errorMessage} socialLoginError={this.props.UserProfileStore.socialLoginError} userid={this.props.UserProfileStore.userid} username={this.props.UserProfileStore.username}/>
+                        <div className="item search">
                             <SearchBox className="item"/>
                         </div>
-                        <div className="ui right inverted blue menu">
-                            <div className="item">
-                              <NavLink routeName="addDeck" activeClass="active" className="ui right labeled icon button" role="button">
-                                  <i className="right plus icon"></i>
-                                  <FormattedMessage id='header.addDeck' defaultMessage='Add deck'/>
-                              </NavLink>
-                            </div>
-                            {notification_locale}
-                            <div className="item">{loginButton}<LoginModal errorMessage={this.props.UserProfileStore.errorMessage} socialLoginError={this.props.UserProfileStore.socialLoginError} userid={this.props.UserProfileStore.userid} username={this.props.UserProfileStore.username}/></div>
-                        </div>
                     </div>
-                </div>
-              </MediaQuery>
-              <MediaQuery maxDeviceWidth={767}>
-                <div className="ui inverted blue menu" style={{borderRadius: '0px'}} ref="header">
-                  <button className="ui icon button item" onClick={this.toggleSidebar.bind(this)}><i className="content icon"/></button>
-                  <div className="ui right inverted blue menu">
-                    <NavLink className="item" href='/'>
-                        <i className="home icon"/><FormattedMessage id='header.slidewiki' defaultMessage='SlideWiki'/>
-                    </NavLink>
-                  </div>
-                </div>
-                <div className="ui inverted left dimmed sidebar vertical menu menubar" ref="menubar" onClick={this.closeSidebar.bind(this)}>
-                    <NavLink className="item" href='/'>
-                        <i className="home icon"/><FormattedMessage id='header.menu.homepage' defaultMessage='Homepage'/>
-                    </NavLink>
-                    <NavLink className="item" routeName="addDeck">
-                        <i className="add icon"/><FormattedMessage id='header.menu.addDeck' defaultMessage='Add Deck'/>
-                    </NavLink>
-                    <div className="item" onClick={this.toggleLanguageBar.bind(this)}>
-                        <i className="caret right icon"/>
-                        <LocaleSwitcher mode="headeronly"/>
+                    <div className="ui inverted left dimmed sidebar vertical menu" ref="languagebar">
+                        <LocaleSwitcher mode="sidebar"/>
                     </div>
-                    {mobileLoginButton}
-                    <LoginModal errorMessage={this.props.UserProfileStore.errorMessage} socialLoginError={this.props.UserProfileStore.socialLoginError} userid={this.props.UserProfileStore.userid} username={this.props.UserProfileStore.username}/>
-                    <div className="item search">
-                        <SearchBox className="item"/>
-                    </div>
-                </div>
-                <div className="ui inverted left dimmed sidebar vertical menu" ref="languagebar">
-                    <LocaleSwitcher mode="sidebar"/>
-                </div>
-              </MediaQuery>
+                </MediaQuery>
             </div>
         );
     }


### PR DESCRIPTION
Made MediaQuery take into account not the width of the device, but the width of the web page. This fixes the issue with not working Hamburger menu on desktop computers with modern screen resolution.