### PR TITLE
Add nlp to microservices template and SERVICE_URL_NLP to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ slidewikiplatform:
     - SERVICE_URL_TRANSLATION=https://translationservice.experimental.slidewiki.org
     - SERVICE_URL_SIGNALING=https://signalingservice.experimental.slidewiki.org
     - SERVICE_URL_QUESTION=https://questionservice.experimental.slidewiki.org
+    - SERVICE_URL_NLP=https://nlpservice.experimental.slidewiki.org
     - SERVICE_VAR_IMPORT_HOST=importservice.experimental.slidewiki.org
     - SERVICE_USER_APIKEY=2cbc621f86e97189239ee8c4c80b10b3a935b8a9f5db3def7b6a3ae7c4b75cb5
     - SERVICE_USER_PRIVATE_RECAPTCHA_KEY=6LdNLyYTAAAAAFMC0J_zuVI1b9lXWZjPH6WLe-vJ

--- a/microservices.js.template
+++ b/microservices.js.template
@@ -48,6 +48,9 @@ export default {
         },
         'questions': {
             uri: '${SERVICE_URL_QUESTION}'
+        }, 
+        'nlp': {
+            uri: '${SERVICE_URL_NLP}'
         }
     }
 };


### PR DESCRIPTION
I noticed that the platform cannot establish connection with the nlp service on experimental, so I added nlp service to microservices.js.template and the respective env var to docker-compose.yml