### PR TITLE
SWIK-2100 removes N and H shortcut

### DIFF
--- a/components/Deck/Presentation/Presentation.js
+++ b/components/Deck/Presentation/Presentation.js
@@ -89,7 +89,11 @@ class Presentation extends React.Component{
                     { src: '/custom_modules/reveal.js/plugin/zoom-js/zoom.js', async: true }
                     // Plugin from https://github.com/marcysutton/reveal-a11y
                     //{ src: '/custom_modules/reveal.js/plugin/accessibility/helper.js', async: false,condition: function() {return !!document.body.classList;}}
-                ]
+                ],
+                keyboard: {
+                    72: null,
+                    78: null
+                }
             });
 
 


### PR DESCRIPTION
Removes support for these keyboard bindings because they conflict with screenreaders. Should be done with associated reveal.js PR