### PR TITLE
SWIK-2142 remove margin to use full screen presentation

### DIFF
--- a/components/Deck/Presentation/Presentation.js
+++ b/components/Deck/Presentation/Presentation.js
@@ -79,7 +79,7 @@ class Presentation extends React.Component{
             Reveal.initialize({
                 width: pptxwidth,
 			         height: pptxheight,
-                margin: 0.2,
+                // margin: 0.2,
                 transition: 'none',
                 backgroundTransition: 'none',
                 history: true,


### PR DESCRIPTION
Removes margin, so the presentation should use full screen.  Associated PR in reveal.js.

NOTE: Overflow is currently set to visible, unlike in slide view. Easy to change to `overflow:hidden` for consistency, depending on what we prefer.