### PR TITLE
fix the issue of loading the slide editor for the first time after page refresh

### DIFF
--- a/actions/slide/loadSlideView.js
+++ b/actions/slide/loadSlideView.js
@@ -23,6 +23,7 @@ export default function loadSlideView(context, payload, done) {
             return;
         } else {
             context.dispatch('LOAD_SLIDE_CONTENT_SUCCESS', res);
+            context.dispatch('LOAD_SLIDE_EDIT_SUCCESS', res);
         }
         let deckTitle = context.getStore(DeckTreeStore).getState().deckTree.get('title');
         let pageTitle = shortTitle + ' | ' + deckTitle + ' | ' + res.slide.revisions[0].title;

--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/SlideContentEditor.js
@@ -2138,7 +2138,7 @@ class SlideContentEditor extends React.Component {
         // Add the CSS dependency for the theme
         // Get the theme information, and download the stylesheet
         let styleName = 'default';
-        if(this.props.selector.theme && typeof this.props.selector.theme !== 'undefined'){
+        if(this.props.selector && this.props.selector.theme && typeof this.props.selector.theme !== 'undefined'){
             styleName = this.props.selector.theme;
         } else {
             // we need to figure out the theme based on the parent deck


### PR DESCRIPTION
@kadevgraaf To solve the issue with loading of slide editor on page refresh, I applied the following trick:
- I pre-load the slide edit store when slide view store is loaded. It works as a workaround but we still need to solve the issue of making SlideEditor a stand-alone component so that people can directly go to the edit mode. In the current situation, if you don't view the slide, you can not edit it.