### PR TITLE
Fix deck view panel slide thumbnail links showing deck edit

### DIFF
--- a/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
@@ -213,13 +213,13 @@ class DeckViewPanel extends React.Component {
                                 if (index < maxSlideThumbnails) {
                                     return (
                                         <div key={index} className="ui card">
-                                            <NavLink href={deckURL + '/slide/' + slide.id} className="ui image"
+                                            <a href={deckURL + '/slide/' + slide.id} className="ui image"
                                                tabIndex="-1">
                                                 <img key={index} src={thumbnailURL} alt={thumbnailAlt} tabIndex={-1}/>
-                                            </NavLink>
+                                            </a>
                                             <div className="content" tabIndex="-1">
-                                                <NavLink href={deckURL + '/slide/' + slide.id}
-                                                   className='header' tabIndex="0" aria-describedby={'slide-no-'+index}>{this.getTextFromHtml(slide.title)}</NavLink>
+                                                <a href={deckURL + '/slide/' + slide.id}
+                                                   className='header' tabIndex="0" aria-describedby={'slide-no-'+index}>{this.getTextFromHtml(slide.title)}</a>
                                                 <div className="description" id={'slide-no-'+index}>Slide {index + 1} of {totalSlides}</div>
                                             </div>
                                         </div>


### PR DESCRIPTION
This is a partial revert to quickly fix this issue for the release.
Some links when implemented as NavLink don't work correctly,
reverted to using <a> tags.