### PR TITLE
Apply some minor fixes to work with new language codes in deck service

### DIFF
--- a/components/AddDeck/AddDeck.js
+++ b/components/AddDeck/AddDeck.js
@@ -93,7 +93,7 @@ class AddDeck extends React.Component {
         else {
             wrongFields.title = false;
         }
-        if (language === null || language === undefined || language.length !== 5) {
+        if (language === null || language === undefined || language.length < 2) {
             wrongFields.language = true;
             everythingIsFine = false;
         }

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -43,7 +43,7 @@ class DeckPropertiesEditor extends React.Component {
             validationErrors: {},
             title: props.deckProps.title || '',
             allowMarkdown: props.deckProps.allowMarkdown || false,
-            language: props.deckProps.language || '',
+            language: (props.deckProps.language && props.deckProps.language.replace('-', '_')) || '',
             description: props.deckProps.description || '',
             theme: props.deckProps.theme || '',
             //license: props.deckProps.license || '',
@@ -202,7 +202,7 @@ class DeckPropertiesEditor extends React.Component {
             isValid = false;
         }
 
-        if (this.state.language == null || this.state.language.length !== 5) {
+        if (this.state.language == null || this.state.language.length < 2) {
             validationErrors.language = 'Please select a language.';
             isValid = false;
         }
@@ -255,6 +255,7 @@ class DeckPropertiesEditor extends React.Component {
     handleChange(fieldName, event) {
         let stateChange = {};
         stateChange[fieldName] = event.target.value;
+        if (fieldName === 'language') stateChange[fieldName] = stateChange[fieldName].replace('-', '_');
         this.setState(stateChange);
     }
     onChangeMarkdown(event) {
@@ -497,6 +498,21 @@ class DeckPropertiesEditor extends React.Component {
         //
         */
 
+        // TODO remove this once language codes have been fixed in code and database
+        const fixedLanguageCodes = {
+            'en': 'en_GB',
+            'de': 'de_DE',
+            'fr': 'fr_FR',
+            'it': 'it_IT',
+            'es': 'es_ES',
+            'nl': 'nl_NL',
+            'el': 'el_GR',
+            'pt': 'pt_PT',
+            'sr': 'sr_RS',
+            'lt': 'lt_LT',
+        };
+        let simpleLanguage = this.state.language && fixedLanguageCodes[this.state.language.substring(0, 2)];
+
         let groupsArray = [];
         if (this.props.groups) {
             this.props.groups.forEach((group) => {
@@ -567,7 +583,7 @@ class DeckPropertiesEditor extends React.Component {
                 <label htmlFor="language" id="language_label">
                     Language
                 </label>
-                <LanguageDropdown type="spoken" required={true} value={this.state.language} arialabel="language" onChange={this.handleChange.bind(this, 'language')} />
+                <LanguageDropdown type="spoken" required={true} value={simpleLanguage} arialabel="language" onChange={this.handleChange.bind(this, 'language')} />
             </div>
         </div>;
         let markdownField = <div className="field">

--- a/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckViewPanel/DeckViewPanel.js
@@ -112,6 +112,7 @@ class DeckViewPanel extends React.Component {
         const deckCreator = this.props.DeckViewStore.creatorData.username;
         const deckOwner = this.props.DeckViewStore.ownerData.username;
         const originCreator = this.props.DeckViewStore.originCreatorData.username;
+        if (deckData.language) deckData.language = deckData.language.substring(0, 2);
 
         let deckLanguageCode = deckData.language === undefined ? 'en' : deckData.language;
         let deckLanguage = deckLanguageCode === undefined ? '' : ISO6391.getName(deckLanguageCode);


### PR DESCRIPTION
This patch will make current master compatible with some language code fixes we have agreed upon: 
- we are going to be using two-character language codes ([ISO-639-1](https://en.wikipedia.org/wiki/ISO_639-1))
- a fix for the existing database data will be applied to the mongodb data using `truncatelangs` command of https://github.com/slidewiki/slidewiki-data-utils


This is a transitional code change that will be refined once the translations PRs are merged: https://github.com/slidewiki/deck-service/pull/136 and https://github.com/slidewiki/slidewiki-platform/pull/899.

This will also allow the deck service PR to be merged, so that we'll be able to properly review / test the platform PR.


