### PR TITLE
Replace src with data-src to enable lazy loading

### DIFF
--- a/components/Deck/Presentation/PresentationSlide.js
+++ b/components/Deck/Presentation/PresentationSlide.js
@@ -8,9 +8,18 @@ import SlideViewStore from '../../../stores/SlideViewStore';
 let sectionStyle = { 'top': 'unset !important'};
 
 class PresentationSlide extends React.Component {
+    constructor(props) {
+        super(props);
+        this.replaced = false;
+    }
     render(){
+        let slideContent = '';
+        if (this.replaced === false && this.props.content !== ''){
+            slideContent = this.props.content.replace(/ src=/g, ' data-src=');
+            this.replaced = true;
+        }
         return (
-            <section dangerouslySetInnerHTML={{__html:this.props.content}} id={this.props.id} />
+            <section dangerouslySetInnerHTML={{__html:slideContent}} id={this.props.id} />
         );
     }
 


### PR DESCRIPTION
I cannot see a lot of difference in performance, e.g., between the same
presentation on
http://localhost:3000/presentation/2201-1/test-a-big-big-big-deck/2201-1
/#/slide-12856-1 and on
https://platform.experimental.slidewiki.org/presentation/2201-1/test-a-b
ig-big-big-deck/2201-1/#/slide-12788-1 (without data-src)