### PR TITLE
SWIK-2331 Fix slideshow links in Recommended decks panel

### DIFF
--- a/stores/UserRecommendationsStore.js
+++ b/stores/UserRecommendationsStore.js
@@ -1,4 +1,5 @@
 import {BaseStore} from 'fluxible/addons';
+import slug from 'slug';
 
 class UserRecommendationsStore extends BaseStore {
     constructor(dispatcher) {
@@ -25,7 +26,8 @@ class UserRecommendationsStore extends BaseStore {
                 description: deck.description,
                 creationDate: deck.timestamp,
                 noOfLikes: deck.noOfLikes,
-                recommendationWeight: deck.recommendationWeight
+                recommendationWeight: deck.recommendationWeight,
+                slug: slug(activeRevision.title).toLowerCase() || '_'
             };
         });
 


### PR DESCRIPTION
There were some changes in the DeckCard component which cause an issue with slideshow links in the RecommendedDecks panel. This very small fix adds slugs to recommended decks to fix this.