### PR TITLE
[SWIK-2370_displayName_in_deckeditors]

### DIFF
--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -330,7 +330,7 @@ class DeckPropertiesEditor extends React.Component {
                                 <div className="ten wide column">
                                     <div className="content">
                                         <TextArea className="sr-only" id={'usernameIsALinkHint' + key} value="The username is a link which will open a new browser tab. Close it when you want to go back to this page." tabIndex ='-1'/>
-                                        <a className="header" href={'/user/' + user.username} target="_blank">{user.username}</a>
+                                        <a className="header" href={'/user/' + user.username} target="_blank">{user.displayName || user.username}</a>
                                         <div className="description">
                                             {optionalElement}{optionalText}
                                         </div>


### PR DESCRIPTION
Now editors are displayed with their displayName. Groups detail Modal is already using the new attribute.