### PR TITLE
Fix - showing 'Owned decks' instead of 'My decks' for other users

### DIFF
--- a/components/User/UserProfile/PrivatePublicUserProfile/UserMenu.js
+++ b/components/User/UserProfile/PrivatePublicUserProfile/UserMenu.js
@@ -39,25 +39,14 @@ class UserMenu extends React.Component {
         });
     }
     render() {
-        let deckRecommendationsMsg = this.context.intl.formatMessage(this.messages.recommendedDecks);
-        let deckRecommendationNavLink = (
-            <NavLink className="item" href={'/user/' + this.props.user.uname + '/recommendations'} activeStyle={this.styles}>
-                <p><i className="icons">
-                    <i className="yellow open folder icon"></i>
-                    <i className="corner thumbs up icon"></i>
-                </i> {deckRecommendationsMsg}</p>
-            </NavLink>
-        );
-
         let decksMsg = this.context.intl.formatMessage(this.messages.myDecks);
         let sharedDecksMsg = this.context.intl.formatMessage(this.messages.sharedDecks);
         let deckCollectionsMsg = this.context.intl.formatMessage(this.messages.collections);
+        let deckRecommendationsMsg = this.context.intl.formatMessage(this.messages.recommendedDecks);
 
-        //Remove link if it's not user's own page //Until recommendation service is properly integrated into the system, show only on experimental
-        if(this.props.user.uname !== this.props.loggedinuser || Microservices.recommendation === undefined || Microservices.recommendation.uri !== 'http://slidewiki.imp.bg.ac.rs') {
+        if(this.props.user.uname !== this.props.loggedinuser) {
             decksMsg = this.context.intl.formatMessage(this.messages.ownedDecks);
             deckCollectionsMsg = this.context.intl.formatMessage(this.messages.ownedCollections);
-            deckRecommendationNavLink = '';
         }
 
         return (
@@ -74,7 +63,14 @@ class UserMenu extends React.Component {
                                 </i> {sharedDecksMsg}</p>
                     </NavLink>
                   }
-                  {deckRecommendationNavLink}
+                  { (this.props.user.uname === this.props.loggedinuser && Microservices.recommendation !== undefined && Microservices.recommendation.uri === 'http://slidewiki.imp.bg.ac.rs') &&
+                    <NavLink className="item" href={'/user/' + this.props.user.uname + '/recommendations'} activeStyle={this.styles}>
+                        <p><i className="icons">
+                            <i className="yellow open folder icon"></i>
+                            <i className="corner thumbs up icon"></i>
+                        </i> {deckRecommendationsMsg}</p>
+                    </NavLink>
+                  }
                   <NavLink className="item" href={'/user/' + this.props.user.uname + '/playlists'} activeStyle={this.styles} role="menuitem">
                       <p><i className="icon grid layout"/> {deckCollectionsMsg}</p>
                   </NavLink>


### PR DESCRIPTION
There was a small bug in my implementation of recommended decks functionality which caused 'Owned decks' to be displayed instead of 'My decks' (except on experimental). :( This is a fix for that.
I've changed back the condition for showing 'Owned decks' instead of 'My decks':
if(this.props.user.uname !== this.props.loggedinuser) {   ...