### PR TITLE
SWIK-2429 fixing Publication year removed when edit Sources

### DIFF
--- a/components/Deck/ContentModulesPanel/DataSourcePanel/EditDataSource.js
+++ b/components/Deck/ContentModulesPanel/DataSourcePanel/EditDataSource.js
@@ -99,7 +99,7 @@ class EditDataSource extends React.Component {
             dataSource.url = this.refs.url.value;
             dataSource.comment = this.refs.comment.value;
             dataSource.authors = this.refs.authors.value;
-            dataSource.year = this.refs.authors.year;
+            dataSource.year = this.refs.year.value;
         }
         this.context.executeAction(updateDataSources, {
             dataSources: dataSources,


### PR DESCRIPTION
This is a very small fix of a typo which prevented saving the year field when editing datasources.