### PR TITLE
hot-fix remove pdf option from download modal as broken

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/DownloadModal.js
+++ b/components/Deck/ContentPanel/ContentActions/DownloadModal.js
@@ -203,7 +203,7 @@ class DownloadModal extends React.Component{
 
                                    <Grid.Column textAlign='left' width={13} role="radiogroup" aria-labelledby="downloadModalDescription">
                                     <div  id="downloadModalDescription" tabIndex='0'>{this.context.intl.formatMessage(this.messages.downloadModal_description)}</div>
-                                     <Form.Field >
+                                   {/*  <Form.Field >
                                           <Radio
                                             label='PDF'
                                             name='downloadRadioGroup'
@@ -216,7 +216,7 @@ class DownloadModal extends React.Component{
                                             tabIndex="0"
 
                                             />
-                                      </Form.Field>
+                                      </Form.Field> */}
                                       <Form.Field>
                                         <Radio
                                           label={this.context.intl.formatMessage(this.messages.downloadModal_HTML)}


### PR DESCRIPTION
Commented out option for PDF in the download modal as it is broken. New print view can be saved to PDF