### PR TITLE
SWIK-1956 Fixes error message in browser console on homepage

### DIFF
--- a/components/Login/LoginModal.js
+++ b/components/Login/LoginModal.js
@@ -344,7 +344,7 @@ class LoginModal extends React.Component {
         <div className="ui one column grid">
           <div className="ui center aligned column">
             <textarea className="sr-only" id="signinModalDescription"
-            value="Use your user email address and password to sign in. Or select GooglePlus or GitHub if you have used thesse services to active your account on SlideWiki"
+            defaultValue="Use your user email address and password to sign in. Or select GooglePlus or GitHub if you have used thesse services to active your account on SlideWiki"
             tabIndex ='-1'/>
             <div className={inputField_classes}>
               <div><label htmlFor="email1" hidden>


### PR DESCRIPTION
This PR fixes SWIK-1956.

This bug has existed because of a textarea that is NOT displayed in the LoginModal. Is the textarea needed at all? There is only a description text in the textarea (that isn't displayed in the modal). @abijames Or is needed because of e.g. accessibility reasons?
If not, I'd prefer to remove the textarea.