### PR TITLE
SWIK-2475 Fixes mobile header bar issues

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -91,7 +91,7 @@ class Header extends React.Component {
 
         return (
             <div>
-                <MediaQuery minWidth={768} values={{width: 1600}}>
+                <MediaQuery minWidth={1050} values={{width: 1600}}>
                     <div className="ui inverted blue menu" ref="header" style={{borderRadius: '0px'}}>
                         <div className="ui fluid container">
                             <a className="item" href='/'>
@@ -113,7 +113,7 @@ class Header extends React.Component {
                         </div>
                     </div>
                 </MediaQuery>
-                <MediaQuery maxWidth={768} values={{width: 1600}}>
+                <MediaQuery maxWidth={1049} values={{width: 1600}}>
                     <div className="ui inverted blue menu" style={{borderRadius: '0px', marginBottom: '0.1rem'}} ref="header">
                         <button className="ui icon button item" onClick={this.toggleSidebar.bind(this)}><i className="content icon"/>
                           &nbsp;&nbsp;<img src="/assets/images/slideWiki-logo-linear.png" alt="SlideWiki Logo" style={{width: '9rem', paddingTop: '0.5rem'}}/>


### PR DESCRIPTION
This PR fixes that the header bar is displayed twice on an IPAD (emulation in chrome) and thus having two login modals opened up.
Furthermore I've increased the threshold to jump to the desktop view, as some buttons were not available on the homepage on e.g. an IPAD.

This won't fix the request to use em instead of px, as the framework has no support for em.

@abijames Is it okay to show the mobile bar till 1050 pixels? Before it was set to 768 pixels, but e.g. the login button wasn't displayed on screens that are e.g. 900px wide.