### PR TITLE
increase the URL req slice

### DIFF
--- a/server/handleServerRendering.js
+++ b/server/handleServerRendering.js
@@ -44,18 +44,19 @@ let renderApp = function(req, res, context){
 
 
     //todo: for future, we can choose to not include specific scripts in some predefined layouts
+    //todo: if our deck IDs exceed a number of digits, slice of 0-20 might not be a good idea
     let layout = HTMLComponent;
     if(req.url && (req.url.slice(0,20).includes('/Presentation')|| req.url.slice(0,20).includes('/presentation'))){//NOTE only test first few chars as presentaton rooms URL has "/Presentation/..." also in it
         layout = PresentorComponent;
     }
-    if(req.url && (req.url.slice(0,20).includes('/presentationIE'))){
-        layout = PresentorIEComponent;
-    }
     if(req.url && (req.url.slice(0,20).includes('/print'))){
         layout = PresentationPrintComponent;
     }
-    if(req.url && (req.url.slice(0,20).includes('/neo4jguide'))){
+    if(req.url && (req.url.includes('/neo4jguide'))){
         layout = BasicHTMLLayout;
+    }
+    if(req.url && (req.url.includes('/presentationIE'))){
+        layout = PresentorIEComponent;
     }
     if(req.url && req.url.includes('/presentationbroadcast')){
         layout = PresentationRoomsComponent;


### PR DESCRIPTION
it is for using different layouts based on different keywords used in the req url e.g. presentationIE, print, neo4jguide, etc.. For some of these identifiers, we use a slice of 0,20 from the req url that might become tricky in future if our deck ids get very large...