### PR TITLE
SWIK-2512 Fix fetchUserDecks imports

### DIFF
--- a/components/DeckCollection/Modals/AddDecksModal/AddDecksModal.js
+++ b/components/DeckCollection/Modals/AddDecksModal/AddDecksModal.js
@@ -5,7 +5,7 @@ import { navigateAction } from 'fluxible-router';
 import { Button, Icon, Modal, Header, Image, Segment, TextArea, Menu, Popup, Container } from 'semantic-ui-react';
 import FocusTrap from 'focus-trap-react';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import { fetchUserDecks } from '../../../../actions/user/userprofile/fetchUserDecks';
+import fetchUserDecks from '../../../../actions/user/userprofile/fetchUserDecks';
 import { fetchNextUserDecks } from '../../../../actions/user/userprofile/fetchNextUserDecks';
 import DeckCollectionStore from '../../../../stores/DeckCollectionStore';
 import DecksList from './DecksList';

--- a/components/User/UserProfile/PrivatePublicUserProfile/PrivatePublicUserProfile.js
+++ b/components/User/UserProfile/PrivatePublicUserProfile/PrivatePublicUserProfile.js
@@ -8,7 +8,7 @@ import UserCollections from '../../../DeckCollection/UserCollections';
 import UserMenu from './UserMenu';
 import UserRecommendations from '../UserRecommendations';
 import classNames from 'classnames/bind';
-import { fetchUserDecks } from '../../../../actions/user/userprofile/fetchUserDecks';
+import fetchUserDecks from '../../../../actions/user/userprofile/fetchUserDecks';
 
 class PrivatePublicUserProfile extends React.Component {
     constructor(props){

--- a/components/User/UserProfile/PrivatePublicUserProfile/UserDecks.js
+++ b/components/User/UserProfile/PrivatePublicUserProfile/UserDecks.js
@@ -4,7 +4,7 @@ import PopularDecks from '../PopularDecks';
 import { navigateAction } from 'fluxible-router';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { Button, Icon } from 'semantic-ui-react';
-import { fetchUserDecks } from '../../../../actions/user/userprofile/fetchUserDecks';
+import fetchUserDecks from '../../../../actions/user/userprofile/fetchUserDecks';
 import { fetchNextUserDecks } from '../../../../actions/user/userprofile/fetchNextUserDecks';
 
 class UserDecks extends React.Component {


### PR DESCRIPTION
This is a very small bug fix, easy to check and merge.
A recent commit has changed
`export function fetchUserDecks(context, payload, done) {`
to 
`export default function fetchUserDecks(context, payload, done) {`
However, there are still
`import { fetchUserDecks }`
in a couple of places and this brakes some things (add decks to playlist, sorting and filtering on 'My decks' page)