### PR TITLE
Swik 1440 improve slide links in notifications

### DIFF
--- a/components/Deck/ActivityFeedPanel/util/ActivityFeedUtil.js
+++ b/components/Deck/ActivityFeedPanel/util/ActivityFeedUtil.js
@@ -67,6 +67,8 @@ class ActivityFeedUtil {
         let msPerYear = msPerDay * 365;
 
         let elapsed = nowTime - thenTime;
+        if (elapsed < 0)
+            elapsed = 0;
 
         if (elapsed < msPerMinute) {
             return Math.round(elapsed/1000) + ' seconds ago';

--- a/components/User/UserNotificationsPanel/UserNotificationsItem.js
+++ b/components/User/UserNotificationsPanel/UserNotificationsItem.js
@@ -41,7 +41,7 @@ class UserNotificationsItem extends React.Component {
             notification.user_id = undefined;
         }
 
-        let viewPath = ((notification.content_kind === 'slide') ? '/slideview/' : '/deck/') + notification.content_id;
+        let viewPath = (notification.content_kind === 'deck') ? '/deck/' + notification.content_id : (notification.slidePath && notification.slidePath !== '') ? notification.slidePath : '/slideview/' + notification.content_id;
         const cheerioContentName = (notification.content_name !== undefined) ? cheerio.load(notification.content_name).text() : '';
         if (notification.content_kind === 'group')
             viewPath = '/user/' + this.props.username + '/groups/overview';

--- a/services/notifications.js
+++ b/services/notifications.js
@@ -1,5 +1,6 @@
 import {Microservices} from '../configs/microservices';
 import rp from 'request-promise';
+import Util from '../components/common/Util';
 const log = require('../configs/log').log;
 
 export default {
@@ -15,10 +16,40 @@ export default {
         }
 
         if (resource === 'notifications.list'){
-
             rp.get({uri: Microservices.notification.uri + '/notifications/' + uid + '?metaonly=false'}).then((res) => {
                 let notifications = JSON.parse(res).items;
-                callback(null, {notifications: notifications});
+                
+                //create path for slides - GET DECK DATA for content_root_id FROM DECK SERVICE
+                let deckTreePromises = [];
+                for(let notification of notifications){
+                    if (notification.content_kind === 'slide' && notification.content_root_id) {
+                        deckTreePromises.push(
+                            rp.get({
+                                uri: `${Microservices.deck.uri}/decktree/${notification.content_root_id}`,
+                                json: true
+                            })
+                        );
+                    }
+                }
+                
+                Promise.all(deckTreePromises).then( (data) => {
+                    let deckTrees = data;
+                    for (let i = 0; i < deckTrees.length; i++) {
+                        let deckTree = makePathForTree(deckTrees[i], []);
+                        let deckId = deckTree.id;
+                        let flatTree = flattenTree(deckTree);
+                        for (let j = 0; j < notifications.length; j++) {
+                            if (notifications[j].content_kind === 'slide' && notifications[j].content_root_id && notifications[j].content_root_id.split('-')[0] === deckId.split('-')[0]) {
+                                notifications[j].slidePath = getSlidePath(notifications[j].content_id, deckId, flatTree);
+                            }
+                        }
+                    }
+                    
+                    callback(null, {notifications: notifications});
+                }).catch( (err) => {
+                    console.log(err);
+                    callback(null, {notifications: []});
+                });
             }).catch((err) => {
                 console.log(err);
                 callback(null, {notifications: []});
@@ -116,3 +147,80 @@ export default {
     // create: (req, resource, params, body, config, callback) => {},
 
 };
+
+//return the position of the node in the deck
+function getSlidePath(slideId, deckId, flatTree){
+    let path = '';
+    for (let i = 0; i < flatTree.length; i++) {
+        if (flatTree[i].type === 'slide' && flatTree[i].id === slideId) {
+            path = flatTree[i].path;
+            let nodeSelector = {id: deckId, stype: 'slide', sid: slideId, spath: path};
+            let nodeURL = Util.makeNodeURL(nodeSelector, 'deck', 'view', undefined, undefined, true);
+
+            return nodeURL;
+        }
+    }
+    return path;
+}
+
+//flat tree is used to avoid complex recursive functions on tree
+//it is a trade off: updating the tree needs this to be synchronized
+//this also propagates themes from decks to slide children
+function flattenTree(deckTree, theme) {
+    if (!theme) theme = deckTree.theme;
+
+    let list = [];
+    list.push({
+        id: deckTree.id,
+        title: deckTree.title,
+        type: deckTree.type,
+        path: deckTree.path,
+        language: deckTree.language,
+        theme: theme
+    });
+
+    if (deckTree.type === 'deck') {
+        deckTree.children.forEach((item) => {
+            let theme = item.theme;
+            if (item.type === 'slide') theme = deckTree.theme;
+
+            list = list.concat(flattenTree(item, theme));
+        });
+    }
+    return list;
+}
+
+//deckTree: original deckTree from service without path
+//path: array of binary id:position
+function makePathForTree(deckTree, path) {
+    let nodePath = makeSelectorPathString(path);
+    let newTree = {
+        id: deckTree.id,
+        title: deckTree.title,
+        type: deckTree.type,
+        path: nodePath,
+        theme: deckTree.theme,
+        language: deckTree.language,
+        selected: false,
+        editable: false,
+        onAction: 0
+    };
+    if (deckTree.type === 'deck') {
+        newTree.children = [];
+        newTree.expanded = true;
+        deckTree.children.forEach((item, index) => {
+            newTree.children.push(makePathForTree(item, path.concat([[item.id, index + 1]])) );
+        });
+    }
+    return newTree;
+}
+
+//parses the nodePath and builds a selector path for navigation
+function makeSelectorPathString(nodePath) {
+    let out = [], slectorPath = '';
+    nodePath.forEach((element) => {
+        out.push(element.join(':'));
+    });
+    slectorPath = out.join(';');
+    return slectorPath;
+}


### PR DESCRIPTION
Currently, slide links in notifications point to slide-view, which is not good. Using the recently added activity parameter, content_root_id, slide links (in newly created notifications, which contain content_root_id) will point to proper path within a deck (deck-view + slide).