### PR TITLE
Swik 907 delete deck and transfer ownership

### DIFF
--- a/actions/deckedit/deckDeletion.js
+++ b/actions/deckedit/deckDeletion.js
@@ -1,0 +1,14 @@
+const log = require('../log/clog');
+
+export default function deckDeletion(context, payload, done) {
+    log.info(context);
+    context.service.delete('deck.delete', payload, { timeout: 20 * 1000 }, (err, res) => {
+        if (err) {
+            context.dispatch('DELETE_DECK_ERROR', err);
+        }
+        else {
+            context.dispatch('DELETE_DECK_SUCCESS', res);
+        }
+        done();
+    });
+}

--- a/actions/deckedit/deckDeletion.js
+++ b/actions/deckedit/deckDeletion.js
@@ -2,6 +2,7 @@ const log = require('../log/clog');
 
 export default function deckDeletion(context, payload, done) {
     log.info(context);
+    context.dispatch('START_DELETE_DECK');
     context.service.delete('deck.delete', payload, { timeout: 20 * 1000 }, (err, res) => {
         if (err) {
             context.dispatch('DELETE_DECK_ERROR', err);

--- a/actions/deckedit/deckRemove.js
+++ b/actions/deckedit/deckRemove.js
@@ -1,0 +1,15 @@
+const log = require('../log/clog');
+
+export default function deckRemove(context, payload, done) {
+    log.info(context);
+    context.dispatch('START_DELETE_DECK');
+    context.service.delete('deck.remove', payload, { timeout: 20 * 1000 }, (err, res) => {
+        if (err) {
+            context.dispatch('REMOVE_DECK_ERROR', err);
+        }
+        else {
+            context.dispatch('REMOVE_DECK_SUCCESS', res);
+        }
+        done();
+    });
+}

--- a/actions/deckedit/hideTransferOwnershipModal.js
+++ b/actions/deckedit/hideTransferOwnershipModal.js
@@ -1,0 +1,7 @@
+const log = require('../log/clog');
+
+export default function hideTransferOwnershipModal(context, payload, done) {
+    log.info(context);
+    context.dispatch('HIDE_TRANSFER_OWNERSHIP_MODAL', {});
+    done();
+}

--- a/actions/deckedit/loadEditors.js
+++ b/actions/deckedit/loadEditors.js
@@ -1,0 +1,36 @@
+const log = require('../log/clog');
+
+export default function loadEditors(context, payload, done) {
+    log.info(context);
+    context.dispatch('START_TRANSFER_OWNERSHIP');
+    const groupids = payload.groups.map((group) => parseInt(group.id, 10));
+
+    if (groupids.length < 1) {
+        context.dispatch('LOAD_EDITORS_LIST_SUCCESS', payload.users);
+        return done();
+    }
+
+    context.service.read('usergroup.getList', {groupids}, { timeout: 20 * 1000 }, (err, res) => { // payload needs groupids
+        if (err) {
+            context.dispatch('LOAD_EDITORS_LIST_ERROR', err);
+        }
+        else {
+            let users = payload.users;
+            users = users.concat(res.reduce((ret, group) => {
+                ret.push(group.creator);
+                return ret.concat(group.members);
+            }, []));
+            //remove duplicates
+            users = users.reduce((ret, user) => {
+                let found = ret.find((u) => ((u.id || u.userid) === (user.id || user.userid)));
+                if (!found) {
+                    ret.push(user);
+                }
+                return ret;
+            }, []);
+            console.log('got all editors', users);
+            context.dispatch('LOAD_EDITORS_LIST_SUCCESS', users);
+        }
+        done();
+    });
+}

--- a/actions/deckedit/transferOwnership.js
+++ b/actions/deckedit/transferOwnership.js
@@ -1,0 +1,15 @@
+const log = require('../log/clog');
+
+export default function transferOwnership(context, payload, done) {
+    log.info(context);
+    context.dispatch('TRY_TRANSFER_OWNERSHIP');
+    context.service.update('deck.transferOwnership', payload, { timeout: 20 * 1000 }, (err, res) => {
+        if (err) {
+            context.dispatch('TRANSFER_OWNERSHIP_ERROR', err);
+        }
+        else {
+            context.dispatch('TRANSFER_OWNERSHIP_SUCCESS', res);
+        }
+        done();
+    });
+}

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -22,6 +22,7 @@ import PermissionsStore from '../../../../../stores/PermissionsStore';
 import updateTheme from '../../../../../actions/updateTheme';
 import {showGroupDetailsModal} from '../../../../../actions/deckedit/functionsForGroupDetailsModal';
 import deckDeletion from '../../../../../actions/deckedit/deckDeletion';
+import deckRemove from '../../../../../actions/deckedit/deckRemove';
 
 import {educationLevels} from '../../../../../lib/isced';
 import TagInput from '../../../ContentModulesPanel/TagsPanel/TagInput';
@@ -82,6 +83,76 @@ class DeckPropertiesEditor extends React.Component {
                 swal({
                     title: 'Success',
                     text: 'The deck was saved.',
+                    type: 'success',
+                    confirmButtonText: 'Confirm',
+                    confirmButtonClass: 'positive ui button',
+                    allowEscapeKey: true,
+                    allowOutsideClick: true,
+                    buttonsStyling: false
+                })
+                    .then(() => {
+                        return true;
+                    })
+                    .catch();
+            }
+            else if (newProps.DeckEditStore.viewstate === 'errorDelete') {
+                swal({
+                    title: 'Error',
+                    text: 'Unknown error while deleting.',
+                    type: 'error',
+                    confirmButtonText: 'Close',
+                    confirmButtonClass: 'negative ui button',
+                    allowEscapeKey: true,
+                    allowOutsideClick: true,
+                    buttonsStyling: false
+                })
+                    .then(() => {
+                        return true;
+                    })
+                    .catch();
+            }
+            else if (newProps.DeckEditStore.viewstate === 'successDelete') {
+                swal({
+                    title: 'Success',
+                    text: 'The deck was deleted.',
+                    type: 'success',
+                    confirmButtonText: 'Confirm',
+                    confirmButtonClass: 'positive ui button',
+                    allowEscapeKey: true,
+                    allowOutsideClick: true,
+                    buttonsStyling: false
+                })
+                    .then(() => {
+                        this.context.executeAction(navigateAction, {
+                            url: '/'
+                        });
+                    })
+                    .catch(() => {
+                        this.context.executeAction(navigateAction, {
+                            url: '/'
+                        });
+                    });
+            }
+            else if (newProps.DeckEditStore.viewstate === 'errorRemove') {
+                swal({
+                    title: 'Error',
+                    text: 'Unknown error while removing.',
+                    type: 'error',
+                    confirmButtonText: 'Close',
+                    confirmButtonClass: 'negative ui button',
+                    allowEscapeKey: true,
+                    allowOutsideClick: true,
+                    buttonsStyling: false
+                })
+                    .then(() => {
+                        return true;
+                    })
+                    .catch();
+            }
+            else if (newProps.DeckEditStore.viewstate === 'successRemove') {
+                swal({
+                    title: 'Success',
+                    text: 'The deck was removed from its parents.',
                     type: 'success',
                     confirmButtonText: 'Confirm',
                     confirmButtonClass: 'positive ui button',
@@ -241,7 +312,7 @@ class DeckPropertiesEditor extends React.Component {
     handleDelete(evt) {
         evt.preventDefault();
 
-        if ( this.props.DeckEditStore.roots && this.props.DeckEditStore.roots.length < 1 ) {
+        if ( this.props.DeckEditStore.roots.length < 1 ) {
             // not used in other decks
 
             if (this.state.editors.length < 1 && this.state.groups.length < 1) {
@@ -257,7 +328,7 @@ class DeckPropertiesEditor extends React.Component {
             // is included as subdeck in one other deck and could not just deleted
             // show modal with 2 options: delete and remove
 
-            const parentRootDecks = this.props.DeckEditStore.roots.map(deck => `<a href="${location.origin}/deck/${deck.id}" target="_blank">${deck.id}</a>`);
+            const parentRootDecks = this.props.DeckEditStore.roots.map((deck) => `<a href="${location.origin}/deck/${deck.id}" target="_blank">${deck.id}</a>`);
             swal({
                 title: 'Deck is in use',
                 html: 'The deck you want to delete is used as a subdeck in the following decks: <br>'
@@ -277,6 +348,7 @@ class DeckPropertiesEditor extends React.Component {
                     console.log(result);
                     // confirm btn
                     // remove deck as node from the parent deck
+                    this.context.executeAction(deckRemove, {id: this.props.DeckEditStore.deckProps.sid.split('-')[0]});
                 })
                 .catch(() => {
                     // cancel btn

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/DeckPropertiesEditor.js
@@ -21,6 +21,7 @@ import TagsStore from '../../../../../stores/TagsStore';
 import PermissionsStore from '../../../../../stores/PermissionsStore';
 import updateTheme from '../../../../../actions/updateTheme';
 import {showGroupDetailsModal} from '../../../../../actions/deckedit/functionsForGroupDetailsModal';
+import deckDeletion from '../../../../../actions/deckedit/deckDeletion';
 
 import {educationLevels} from '../../../../../lib/isced';
 import TagInput from '../../../ContentModulesPanel/TagsPanel/TagInput';
@@ -237,6 +238,60 @@ class DeckPropertiesEditor extends React.Component {
         }
     }
 
+    handleDelete(evt) {
+        evt.preventDefault();
+
+        if ( this.props.DeckEditStore.roots && this.props.DeckEditStore.roots.length < 1 ) {
+            // not used in other decks
+
+            if (this.state.editors.length < 1 && this.state.groups.length < 1) {
+                // no editors - could just be deleted
+                this.context.executeAction(deckDeletion, {id: this.props.DeckEditStore.deckProps.sid.split('-')[0]});
+            }
+            else {
+                // transfer ownership
+
+            }
+        }
+        else {
+            // is included as subdeck in one other deck and could not just deleted
+            // show modal with 2 options: delete and remove
+
+            const parentRootDecks = this.props.DeckEditStore.roots.map(deck => `<a href="${location.origin}/deck/${deck.id}" target="_blank">${deck.id}</a>`);
+            swal({
+                title: 'Deck is in use',
+                html: 'The deck you want to delete is used as a subdeck in the following decks: <br>'
+                    + parentRootDecks.join('<br>')
+                    + '<br><br>You could remove your deck as a subdeck from the listed ones or delete the deck complete which also removes it as subdeck.',
+                type: 'question',
+                showCancelButton: true,
+                confirmButtonText: 'Remove as subdeck',
+                confirmButtonClass: 'ui button',
+                cancelButtonText: 'Delete whole deck',
+                cancelButtonClass: 'negative ui button',
+                allowEscapeKey: true,
+                allowOutsideClick: false,
+                buttonsStyling: false
+            })
+                .then((result) => {
+                    console.log(result);
+                    // confirm btn
+                    // remove deck as node from the parent deck
+                })
+                .catch(() => {
+                    // cancel btn
+                    if (this.state.editors.length < 1 && this.state.groups.length < 1) {
+                        // no editors - could just be deleted
+                        this.context.executeAction(deckDeletion, {id: this.props.DeckEditStore.deckProps.sid.split('-')[0]});
+                    }
+                    else {
+                        // transfer ownership
+
+                    }
+                });
+        }
+    }
+
     handleChange(fieldName, event) {
         let stateChange = {};
         stateChange[fieldName] = event.target.value;
@@ -392,6 +447,7 @@ class DeckPropertiesEditor extends React.Component {
     }
 
     render() {
+        console.log('render edit: published and roots', this.state.published, this.props.DeckEditStore.roots);
         //CSS
         let titleFieldClass = classNames({
             'required': true,
@@ -484,6 +540,9 @@ class DeckPropertiesEditor extends React.Component {
             <div>
                 <button className='ui primary button'
                     onClick={this.handleSave.bind(this)}>Save
+                </button>
+                <button className='negative ui button'
+                    onClick={this.handleDelete.bind(this)}>Delete
                 </button>
                 <button className="ui secondary button"
                     onClick={this.handleCancel.bind(this)}>

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/TransferOwnership.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/TransferOwnership.js
@@ -2,9 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FocusTrap from 'focus-trap-react';
-import {Button, Icon, Modal, Header, TextArea, Segment, Container} from 'semantic-ui-react';
-import {hideGroupDetailsModal} from '../../../../../actions/deckedit/functionsForGroupDetailsModal';
+import {Button, Icon, Modal, Header, TextArea, Segment, Container, Menu} from 'semantic-ui-react';
 import { FormattedMessage, defineMessages } from 'react-intl';
+import UserPicture from '../../../../common/UserPicture';
+import hideTransferOwnershipModal from '../../../../../actions/deckedit/hideTransferOwnershipModal';
+import transferOwnership from '../../../../../actions/deckedit/transferOwnership';
 
 class TransferOwnership extends React.Component {
     constructor(props) {
@@ -15,64 +17,72 @@ class TransferOwnership extends React.Component {
         this.messages = defineMessages({
             modalHeading: {
                 id: 'TransferOwnership.modalHeading',
-                defaultMessage: 'Group details'
+                defaultMessage: 'Transfer Ownership'
             },
+            close: {
+                id: 'TransferOwnership.close',
+                defaultMessage: 'Close'
+            },
+            unknownCountry: {
+                id: 'TransferOwnership.unknownCountry',
+                defaultMessage: 'unknown country'
+            },
+            unknownOrganization: {
+                id: 'TransferOwnership.unknownOrganization',
+                defaultMessage: 'Unknown organization'
+            },
+            linkHint: {
+                id: 'TransferOwnership.linkHint',
+                defaultMessage: 'The username is a link which will open a new browser tab. Close it when you want to go back to this page.'
+            },
+            continue: {
+                id: 'TransferOwnership.continue',
+                defaultMessage: 'Transfer ownership'
+            }
         });
+
+        this.state = {
+            selectedUser: ''
+        };
     }
 
     handleClose() {
 	      $('#app').attr('aria-hidden','false');
-	      this.context.executeAction(hideGroupDetailsModal, {});
+	      this.context.executeAction(hideTransferOwnershipModal, {});
     }
 
     unmountTrap() {
         this.handleClose();
     }
 
+    handleContinue() {
+        $('#app').attr('aria-hidden','false');
+        this.context.executeAction(transferOwnership, {deckid: this.props.deckid, userid: this.state.selectedUser});
+    }
+
     render() {
-        let members = [];
-        //first the creator
-        let optionalText = (this.props.group.creator.organization || this.props.group.creator.country) ?
-            (this.props.group.creator.organization || this.context.intl.formatMessage(this.messages.unknownOrganization)) + ', ' + (this.props.group.creator.country || this.context.intl.formatMessage(this.messages.unknownCountry)) :
-            '';
-        members.push(
-          (
-            <div className="item" key={this.props.group.creator.userid}>
-              <div className="ui grid">
-                <div className="one wide column middle aligned">
-                  <UserPicture picture={ this.props.group.creator.picture } username={ this.props.group.creator.username } avatar={ true } width= { 24 } />
-                </div>
-                <div className="fifteen wide column">
-                  <TextArea className="sr-only" id={'usernameIsALinkHint' + this.props.group.creator.userid} value={this.context.intl.formatMessage(this.messages.linkHint)} tabIndex ='-1'/>
-                  <a className="header" href={'/user/' + this.props.group.creator.username} target="_blank">{this.props.group.creator.displayName || this.props.group.creator.username}</a>
-                  <div className="description">
-                    {this.context.intl.formatMessage(this.messages.groupCreator)}
-                  </div>
-                  {optionalText}
-                </div>
-              </div>
-            </div>
-          )
-        );
-        if (this.props.group.members !== undefined && this.props.group.members.length > 0) {
-            this.props.group.members.forEach((user) => {
-                optionalText = (user.organization || user.country) ?
+        let editors = [];
+
+        if (this.props.users !== undefined && this.props.users.length > 0) {
+            this.props.users.forEach((user) => {
+                const optionalText = (user.organization || user.country) ?
                     (user.organization || this.context.intl.formatMessage(this.messages.unknownOrganization)) + ', ' + (user.country || this.context.intl.formatMessage(this.messages.unknownCountry)) :
                     '';
-                members.push(
+                editors.push(
                   (
-                    <div className="item" key={user.userid}>
+                    <Menu.Item name={'item_' + user.username} key={user.id || user.userid} active={this.state.selectedUser === (user.id || user.userid)} onClick={() => {console.log('onItemClicked'); this.setState({selectedUser: user.id || user.userid});}}>
                       <div className="ui grid">
-                        <div className="one wide column">
-                          <UserPicture picture={ user.picture } username={ user.username } avatar={ true } width= { 24 } />
+                        <div className="two wide column">
+                          <UserPicture picture={ user.picture } username={ user.username } avatar={ true } width= { 30 } size="tiny" />
                         </div>
-                        <div className="fifteen wide column">
-                          <TextArea className="sr-only" id={'usernameIsALinkHint' + user.userid} value={this.context.intl.formatMessage(this.messages.linkHint)} tabIndex ='-1'/>
+                        <div className="fourten wide column">
+                          <TextArea className="sr-only" id={'usernameIsALinkHint' + (user.id || user.userid)} value={this.context.intl.formatMessage(this.messages.linkHint)} tabIndex ='-1'/>
                           <a className="header" href={'/user/' + user.username} target="_blank">{user.displayName || user.username}</a>
+                          <br/>
                           {optionalText}
                         </div>
                       </div>
-                    </div>
+                    </Menu.Item>
                   )
                 );
             });
@@ -84,31 +94,34 @@ class TransferOwnership extends React.Component {
           <Modal dimmer='blurring'
             ref="modal1"
             role='dialog'
-            aria-labelledby='groupdetailsmodal_header'
-						aria-describedby='groupdetailsmodal_content'
+            aria-labelledby='transferownershipmodal_header'
+						aria-describedby='transferownershipmodal_content'
             open={showModal}
             tabIndex="0" >
               <FocusTrap focusTrapOptions={{
                   clickOutsideDeactivates: true,
                   onDeactivate: this.unmountTrap,
-                  initialFocus:'#groupdetailsmodal_content'
+                  initialFocus:'#transferownershipmodal_content'
               }}
                 active={showModal}
                 id="focusTrapGroupDetailsModal"
                 className="header">
-								<Modal.Header as="h1" content={this.context.intl.formatMessage(this.messages.modalHeading)} id='groupdetailsmodal_header'/>
-								<Modal.Content id='groupdetailsmodal_content' tabIndex="0">
+								<Modal.Header as="h1" content={this.context.intl.formatMessage(this.messages.modalHeading)} id='transferownershipmodal_header'/>
+								<Modal.Content id='transferownershipmodal_content' tabIndex="0">
                   <Container>
                     <Segment color="blue" textAlign="center" padded>
                       <Segment attached="bottom" textAlign="left">
-      									<h3 className="header" >{this.props.group.name}</h3>
-      									<p>There are {this.props.group.members.length+1} member{(this.props.group.members.length !== 0) ? 's': ''} in this group.</p>
-      									<div className="ui very relaxed  list">
-      											{members}
-      									</div>
+      									<h3 className="header" ></h3>
+      									<p>There are {this.props.users.length} users which have edit rights to the deck. Select one to transfer the ownership as precondition for deleting the deck.</p>
+      									<Menu size='small' vertical style={{width: "100%"}}>
+      											{editors}
+      									</Menu>
                       </Segment>
                       <Modal.Actions>
-  											<Button onClick={ this.handleClose } role="button" tabIndex="0" aria-label={this.context.intl.formatMessage(this.messages.close)}>
+  											<Button onClick={ this.handleContinue.bind(this) } role="button" tabIndex="0" aria-label={this.context.intl.formatMessage(this.messages.continue)} disabled={this.state.selectedUser === ''} positive>
+  													{this.context.intl.formatMessage(this.messages.continue)}
+  											</Button>
+                        <Button onClick={ this.handleClose } role="button" tabIndex="0" aria-label={this.context.intl.formatMessage(this.messages.close)}>
   													{this.context.intl.formatMessage(this.messages.close)}
   											</Button>
       								</Modal.Actions>
@@ -124,7 +137,7 @@ class TransferOwnership extends React.Component {
     }
 }
 
-GroupDetailsModal.contextTypes = {
+TransferOwnership.contextTypes = {
     executeAction: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired
 };

--- a/components/Deck/ContentPanel/DeckModes/DeckEditPanel/TransferOwnership.js
+++ b/components/Deck/ContentPanel/DeckModes/DeckEditPanel/TransferOwnership.js
@@ -1,0 +1,132 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FocusTrap from 'focus-trap-react';
+import {Button, Icon, Modal, Header, TextArea, Segment, Container} from 'semantic-ui-react';
+import {hideGroupDetailsModal} from '../../../../../actions/deckedit/functionsForGroupDetailsModal';
+import { FormattedMessage, defineMessages } from 'react-intl';
+
+class TransferOwnership extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleClose = this.handleClose.bind(this);
+        this.unmountTrap = this.unmountTrap.bind(this);
+
+        this.messages = defineMessages({
+            modalHeading: {
+                id: 'TransferOwnership.modalHeading',
+                defaultMessage: 'Group details'
+            },
+        });
+    }
+
+    handleClose() {
+	      $('#app').attr('aria-hidden','false');
+	      this.context.executeAction(hideGroupDetailsModal, {});
+    }
+
+    unmountTrap() {
+        this.handleClose();
+    }
+
+    render() {
+        let members = [];
+        //first the creator
+        let optionalText = (this.props.group.creator.organization || this.props.group.creator.country) ?
+            (this.props.group.creator.organization || this.context.intl.formatMessage(this.messages.unknownOrganization)) + ', ' + (this.props.group.creator.country || this.context.intl.formatMessage(this.messages.unknownCountry)) :
+            '';
+        members.push(
+          (
+            <div className="item" key={this.props.group.creator.userid}>
+              <div className="ui grid">
+                <div className="one wide column middle aligned">
+                  <UserPicture picture={ this.props.group.creator.picture } username={ this.props.group.creator.username } avatar={ true } width= { 24 } />
+                </div>
+                <div className="fifteen wide column">
+                  <TextArea className="sr-only" id={'usernameIsALinkHint' + this.props.group.creator.userid} value={this.context.intl.formatMessage(this.messages.linkHint)} tabIndex ='-1'/>
+                  <a className="header" href={'/user/' + this.props.group.creator.username} target="_blank">{this.props.group.creator.displayName || this.props.group.creator.username}</a>
+                  <div className="description">
+                    {this.context.intl.formatMessage(this.messages.groupCreator)}
+                  </div>
+                  {optionalText}
+                </div>
+              </div>
+            </div>
+          )
+        );
+        if (this.props.group.members !== undefined && this.props.group.members.length > 0) {
+            this.props.group.members.forEach((user) => {
+                optionalText = (user.organization || user.country) ?
+                    (user.organization || this.context.intl.formatMessage(this.messages.unknownOrganization)) + ', ' + (user.country || this.context.intl.formatMessage(this.messages.unknownCountry)) :
+                    '';
+                members.push(
+                  (
+                    <div className="item" key={user.userid}>
+                      <div className="ui grid">
+                        <div className="one wide column">
+                          <UserPicture picture={ user.picture } username={ user.username } avatar={ true } width= { 24 } />
+                        </div>
+                        <div className="fifteen wide column">
+                          <TextArea className="sr-only" id={'usernameIsALinkHint' + user.userid} value={this.context.intl.formatMessage(this.messages.linkHint)} tabIndex ='-1'/>
+                          <a className="header" href={'/user/' + user.username} target="_blank">{user.displayName || user.username}</a>
+                          {optionalText}
+                        </div>
+                      </div>
+                    </div>
+                  )
+                );
+            });
+        }
+
+        let showModal = this.props.show;
+
+        return (
+          <Modal dimmer='blurring'
+            ref="modal1"
+            role='dialog'
+            aria-labelledby='groupdetailsmodal_header'
+						aria-describedby='groupdetailsmodal_content'
+            open={showModal}
+            tabIndex="0" >
+              <FocusTrap focusTrapOptions={{
+                  clickOutsideDeactivates: true,
+                  onDeactivate: this.unmountTrap,
+                  initialFocus:'#groupdetailsmodal_content'
+              }}
+                active={showModal}
+                id="focusTrapGroupDetailsModal"
+                className="header">
+								<Modal.Header as="h1" content={this.context.intl.formatMessage(this.messages.modalHeading)} id='groupdetailsmodal_header'/>
+								<Modal.Content id='groupdetailsmodal_content' tabIndex="0">
+                  <Container>
+                    <Segment color="blue" textAlign="center" padded>
+                      <Segment attached="bottom" textAlign="left">
+      									<h3 className="header" >{this.props.group.name}</h3>
+      									<p>There are {this.props.group.members.length+1} member{(this.props.group.members.length !== 0) ? 's': ''} in this group.</p>
+      									<div className="ui very relaxed  list">
+      											{members}
+      									</div>
+                      </Segment>
+                      <Modal.Actions>
+  											<Button onClick={ this.handleClose } role="button" tabIndex="0" aria-label={this.context.intl.formatMessage(this.messages.close)}>
+  													{this.context.intl.formatMessage(this.messages.close)}
+  											</Button>
+      								</Modal.Actions>
+                    </Segment>
+                  </Container>
+								</Modal.Content>
+
+              </FocusTrap>
+						</Modal>
+        );
+
+        window.scrollTo(0, 0);
+    }
+}
+
+GroupDetailsModal.contextTypes = {
+    executeAction: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired
+};
+
+export default TransferOwnership;

--- a/services/deck.js
+++ b/services/deck.js
@@ -561,6 +561,23 @@ export default {
             })
             .catch((err) => callback(err));
         }
+        else if (resource === 'deck.transferOwnership') {
+            return callback(null, {});
+            //TODO
+            rp({
+                method: 'POST',
+                uri: Microservices.deck.uri + '/deck/' + params.deckid + '/transferOwnership',
+                headers: { '----jwt----': params.jwt },
+                json: true,
+                body: {
+                    user: params.userid
+                }
+            })
+            .then((body) => {
+                callback(null, body);
+            })
+            .catch((err) => callback(err));
+        }
     },
     delete: (req, resource, params, config, callback) => {
         req.reqId = req.reqId ? req.reqId : -1;

--- a/services/deck.js
+++ b/services/deck.js
@@ -577,6 +577,18 @@ export default {
             })
             .catch((err) => callback(err));
         }
+        else if (resource === 'deck.delete') {
+            rp({
+                method: 'DELETE',
+                uri: Microservices.deck.uri + '/deck/' + params.id + '/links',
+                headers: { '----jwt----': params.jwt },
+                json: true
+            })
+            .then((body) => {
+                callback(null, body);
+            })
+            .catch((err) => callback(err));
+        }
     }
 };
 

--- a/services/usergroup.js
+++ b/services/usergroup.js
@@ -19,6 +19,21 @@ export default {
                 json: true
             }).then( (response) => callback(null, response.groups))
             .catch( (err) => callback(err));
+        } else if (resource === 'usergroup.getList') {
+            // console.log('service usergroup try to get group with id', params.groupid);
+            rp.post({
+                uri: Microservices.user.uri + '/usergroups',
+                body: params.groupids,
+                json: true
+            })
+            .then((res) => {
+                // console.log('Service got usergroups:', res);
+                callback(null, res);
+            })
+            .catch((err) => {
+                // console.warn('Error', err);
+                callback(err, null);
+            });
         } else {
             // usergroup.read got here
             // console.log('service usergroup try to get group with id', params.groupid);
@@ -36,6 +51,5 @@ export default {
                 callback(err, null);
             });
         }
-
     }
 };

--- a/stores/DeckEditStore.js
+++ b/stores/DeckEditStore.js
@@ -25,6 +25,8 @@ class DeckEditStore extends BaseStore {
         this.showGroupModal = false;
 
         this.queryParams = {};
+
+        this.roots = [];
     }
 
     updateProperties(payload) {
@@ -36,6 +38,9 @@ class DeckEditStore extends BaseStore {
         this.authorizedGroups = JSON.parse(JSON.stringify(payload.deckProps.editors.groups));
         this.originalEditors = JSON.parse(JSON.stringify(payload.deckProps.editors));
         // console.log('Now we have new origin editors:', this.originalEditors);
+
+        this.roots = payload.roots.filter(deck => parseInt(deck.id, 10) !== parseInt(this.deckProps.sid.split('-')[0], 10));
+        // console.log('DeckEditStore roots', payload.roots, this.roots, this.deckProps.sid, this.deckProps.sid.split('-')[0]);
 
         this.emitChange();
     }
@@ -61,6 +66,7 @@ class DeckEditStore extends BaseStore {
             showGroupModal: this.showGroupModal,
             queryParams: this.queryParams,
             showGroupModal: this.showGroupModal,
+            roots: this.roots,
         };
     }
 
@@ -78,6 +84,7 @@ class DeckEditStore extends BaseStore {
         this.originalEditors = state.originalEditors;
         this.showGroupModal = state.showGroupModal;
         this.queryParams = state.queryParams;
+        this.roots = state.roots;
     }
 
     updateAuthorizedUsers(users) {
@@ -112,6 +119,14 @@ class DeckEditStore extends BaseStore {
         this.showGroupModal = false;
         this.emitChange();
     }
+
+    deleteDeckError(error) {
+
+    }
+
+    deleteDeck(data) {
+
+    }
 }
 
 DeckEditStore.storeName = 'DeckEditStore';
@@ -125,7 +140,11 @@ DeckEditStore.handlers = {
     'DECKEDIT_START_QUERY_PARAMS': 'setQueryParams',
 
     //Group details modal
-    'HIDE_GROUP_DETAILS_MODAL': 'hideGroupsDetailsModal'
+    'HIDE_GROUP_DETAILS_MODAL': 'hideGroupsDetailsModal',
+
+    // Deck deletion/removable
+    'DELETE_DECK_ERROR': 'deleteDeckError',
+    'DELETE_DECK_SUCCESS': 'deleteDeck'
 };
 
 export default DeckEditStore;

--- a/stores/DeckEditStore.js
+++ b/stores/DeckEditStore.js
@@ -27,6 +27,8 @@ class DeckEditStore extends BaseStore {
         this.queryParams = {};
 
         this.roots = [];
+        this.showTransferOwnershipModal = false;
+        this.allEditors = [];
     }
 
     updateProperties(payload) {
@@ -67,6 +69,8 @@ class DeckEditStore extends BaseStore {
             queryParams: this.queryParams,
             showGroupModal: this.showGroupModal,
             roots: this.roots,
+            showTransferOwnershipModal: this.showTransferOwnershipModal,
+            allEditors: this.allEditors
         };
     }
 
@@ -85,6 +89,8 @@ class DeckEditStore extends BaseStore {
         this.showGroupModal = state.showGroupModal;
         this.queryParams = state.queryParams;
         this.roots = state.roots;
+        this.showTransferOwnershipModal = state.showTransferOwnershipModal;
+        this.allEditors = state.allEditors;
     }
 
     updateAuthorizedUsers(users) {
@@ -149,6 +155,49 @@ class DeckEditStore extends BaseStore {
         this.emitChange();
         this.viewstate = '';
     }
+
+    startTransferOwnership() {
+        this.viewstate = 'loading';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    editorsLoaded(editors) {
+        this.allEditors = editors;
+        this.viewstate = '';
+        this.showTransferOwnershipModal = true;
+        this.emitChange();
+    }
+
+    errorLoadingEditors(error) {
+        this.viewstate = 'errorEditors';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    hideTOModal() {
+        this.showTransferOwnershipModal = false;
+        this.emitChange();
+    }
+
+    errorTO(error) {
+        this.viewstate = 'errorTransfer';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    successTO() {
+        this.viewstate = 'successTransfer';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    tryTransferOwnership() {
+      this.viewstate = 'loading';
+      this.showTransferOwnershipModal = false;
+      this.emitChange();
+      this.viewstate = '';
+    }
 }
 
 DeckEditStore.storeName = 'DeckEditStore';
@@ -169,7 +218,14 @@ DeckEditStore.handlers = {
     'DELETE_DECK_SUCCESS': 'deleteDeck',
     'START_DELETE_DECK': 'startDeleteDeck',
     'REMOVE_DECK_ERROR': 'removeDeckError',
-    'REMOVE_DECK_SUCCESS': 'removeDeck'
+    'REMOVE_DECK_SUCCESS': 'removeDeck',
+    'START_TRANSFER_OWNERSHIP': 'startTransferOwnership',
+    'LOAD_EDITORS_LIST_SUCCESS': 'editorsLoaded',
+    'LOAD_EDITORS_LIST_ERROR': 'errorLoadingEditors',
+    'HIDE_TRANSFER_OWNERSHIP_MODAL': 'hideTOModal',
+    'TRY_TRANSFER_OWNERSHIP': 'tryTransferOwnership',
+    'TRANSFER_OWNERSHIP_ERROR': 'errorTO',
+    'TRANSFER_OWNERSHIP_SUCCESS': 'successTO'
 };
 
 export default DeckEditStore;

--- a/stores/DeckEditStore.js
+++ b/stores/DeckEditStore.js
@@ -39,7 +39,7 @@ class DeckEditStore extends BaseStore {
         this.originalEditors = JSON.parse(JSON.stringify(payload.deckProps.editors));
         // console.log('Now we have new origin editors:', this.originalEditors);
 
-        this.roots = payload.roots.filter(deck => parseInt(deck.id, 10) !== parseInt(this.deckProps.sid.split('-')[0], 10));
+        this.roots = payload.roots.filter((deck) => parseInt(deck.id, 10) !== parseInt(this.deckProps.sid.split('-')[0], 10));
         // console.log('DeckEditStore roots', payload.roots, this.roots, this.deckProps.sid, this.deckProps.sid.split('-')[0]);
 
         this.emitChange();
@@ -121,11 +121,33 @@ class DeckEditStore extends BaseStore {
     }
 
     deleteDeckError(error) {
-
+        this.viewstate = 'errorDelete';
+        this.emitChange();
+        this.viewstate = '';
     }
 
     deleteDeck(data) {
+        this.viewstate = 'successDelete';
+        this.emitChange();
+        this.viewstate = '';
+    }
 
+    startDeleteDeck() {
+        this.viewstate = 'loading';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    removeDeckError(error) {
+        this.viewstate = 'errorRemove';
+        this.emitChange();
+        this.viewstate = '';
+    }
+
+    removeDeck(data) {
+        this.viewstate = 'successRemove';
+        this.emitChange();
+        this.viewstate = '';
     }
 }
 
@@ -144,7 +166,10 @@ DeckEditStore.handlers = {
 
     // Deck deletion/removable
     'DELETE_DECK_ERROR': 'deleteDeckError',
-    'DELETE_DECK_SUCCESS': 'deleteDeck'
+    'DELETE_DECK_SUCCESS': 'deleteDeck',
+    'START_DELETE_DECK': 'startDeleteDeck',
+    'REMOVE_DECK_ERROR': 'removeDeckError',
+    'REMOVE_DECK_SUCCESS': 'removeDeck'
 };
 
 export default DeckEditStore;


### PR DESCRIPTION
I added a new button to deck edit and a workflow for delete/remove/transfer ownership of a deck. Not all deck routes are working yet.
Please verify that the workflow is correct.
Do you have suggestions for visual improve the user list when transfering ownership?

Missing:
- when being on a subdeck - differences?
- Intl texts