### PR TITLE
SWIK-2542 Hide question panel button on slides

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentModulesPanel.js
+++ b/components/Deck/ContentModulesPanel/ContentModulesPanel.js
@@ -223,7 +223,7 @@ class ContentModulesPanel extends React.Component {
                     });
                     
                     //hide tags and playlists for slide view
-                    if (this.props.ContentModulesStore.selector.stype !== 'deck' && (item.value === 'tags' || item.value === 'playlists')) {
+                    if (this.props.ContentModulesStore.selector.stype !== 'deck' && (item.value === 'tags' || item.value === 'playlists' || item.value === 'questions')) {
                         return;
                     }
                     


### PR DESCRIPTION
Hide the questions button in the content modules panel on slides. 

Questions previously added to slides are able to be edited through the deck level questions tab. 