### PR TITLE
SWIK-2543 Change visibility of questions download button

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionsPanel.js
+++ b/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionsPanel.js
@@ -123,13 +123,16 @@ class ContentQuestionsPanel extends React.Component {
             </button>
         ;
 
+        let downloadQuestionsButton = <QuestionDownloadModal />;
+
         let editButtons = (editPermission) ? <div>
                 {addQuestionButton}
                 {examQuestionsButton}
+                {downloadQuestionsButton}
             </div>
             : '';
 
-        let downloadQuestionsButton = <QuestionDownloadModal />;
+
 
         /*
         let addQuestionButton = (
@@ -160,7 +163,6 @@ class ContentQuestionsPanel extends React.Component {
                                 </div>
                                 <div className="twelve wide column right aligned">
                                     {editButtons}
-                                    {downloadQuestionsButton}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Make Download questions button visible only if user has edit permissions.

Stops any user from being able to download the questions. 