### PR TITLE
SWIK-2584 fix occasional wrong number of questions

### DIFF
--- a/actions/loadContentModules.js
+++ b/actions/loadContentModules.js
@@ -2,15 +2,12 @@ import async from 'async';
 // import { shortTitle } from '../configs/general';
 // import loadContentDiscussion from './contentdiscussion/loadContentDiscussion';
 import loadDataSources from './datasource/loadDataSources';
-import loadDataSourceCount from './datasource/loadDataSourceCount';
-import loadQuestionsCount from './questions/loadQuestionsCount';
 import loadCommentsCount from './contentdiscussion/loadCommentsCount';
 import loadPlaylistsCount from './collections/loadPlaylistsCount';
 import deckContentTypeError from './error/deckContentTypeError';
 import slideIdTypeError from './error/slideIdTypeError';
 import { AllowedPattern } from './error/util/allowedPattern';
 import serviceUnavailable from './error/serviceUnavailable';
-import PermissionsStore from '../stores/PermissionsStore';
 const log = require('./log/clog');
 
 
@@ -35,12 +32,6 @@ export default function loadContentModules(context, payload, done) {
         //     context.executeAction(loadDataSourceCount, payload, callback);
         // },
 
-        (callback) => {
-            let editPermission = (context.getStore(PermissionsStore) && context.getStore(PermissionsStore).permissions && (context.getStore(PermissionsStore).permissions.admin || context.getStore(PermissionsStore).permissions.edit));
-
-            payload.params.nonExamQuestionsOnly = !editPermission;
-            context.executeAction(loadQuestionsCount, payload, callback);
-        },
         (callback) => {
             context.executeAction(loadCommentsCount, payload, callback);
         },

--- a/actions/loadDeck.js
+++ b/actions/loadDeck.js
@@ -21,6 +21,7 @@ import DeckTreeStore from '../stores/DeckTreeStore';
 import TranslationStore from '../stores/TranslationStore';
 import loadPermissions from './permissions/loadPermissions';
 import resetPermissions from './permissions/resetPermissions';
+import loadQuestionsCount from './questions/loadQuestionsCount';
 import loadLikes from './activityfeed/loadLikes';
 import getFollowing from './following/getFollowing';
 import PermissionsStore from '../stores/PermissionsStore';
@@ -148,8 +149,14 @@ export default function loadDeck(context, payload, done) {
                         if (!(payloadCustom.params.stype === 'deck' && payload.query.interestedUser))
                             payloadCustom.params.mode = 'view';
                     }
+                    
+                    let editPermission = (permissions.admin || permissions.edit);
+                    payloadCustom.params.nonExamQuestionsOnly = !editPermission;
+                    context.executeAction(loadQuestionsCount, payloadCustom);
+                    
                     // console.log('now mode is', payloadCustom.params.mode);
                     context.executeAction(loadContent, payloadCustom, callback);
+                    
                 });
             },
             (callback) => {


### PR DESCRIPTION
In this PR, the loadQuestionsCount call (currently executed in loadContentModules) is moved to be executed after loading of edit permission info. Edit permission info is needed because exam questions are not displayed to non-editors. 