### PR TITLE
Swik 2607 fix missing embed icon in share menu

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/EmbedModal.js
+++ b/components/Deck/ContentPanel/ContentActions/EmbedModal.js
@@ -185,7 +185,7 @@ class EmbedModal extends React.Component {
                     trigger={
                         <div className="item" data-value="Embed" role="menuitem" aria-label="Embed" data-tooltip="Embed" tabIndex="0" onClick={this.handleEmbed.bind(this)} onKeyPress={this.handleKeyPress.bind(this)}>
                             <div role="button" className="SocialMediaShareButton Demo__some-network__share-button">
-                                <div style={{width: this.props.size + 'px', height: this.props.size + 'px'}}>
+                                <div style={{width: this.props.size + 'px', height: this.props.size + 'px', fontSize: this.props.fontSize + 'px'}}>
                                     <Icon name="share square" style={{
                                         width: (this.props.size - 2) + 'px',
                                         height: (this.props.size - 2) + 'px',


### PR DESCRIPTION
Sometimes the embed icon was not shown in the share menu. This is fixed by setting the font-size on the parent div