### PR TITLE
Swik 555 fix deck not found handling page

### DIFF
--- a/actions/loadDeck.js
+++ b/actions/loadDeck.js
@@ -40,7 +40,7 @@ export default function loadDeck(context, payload, done) {
 
     // resets the deck view store
     // TODO (what other store to reset ???)
-    context.dispatch('LOAD_DECK_CONTENT_START');
+    context.dispatch('LOAD_DECK_PAGE_START');
 
     if (!(AllowedPattern.DECK_ID.test(payload.params.id))) {
         context.executeAction(deckIdTypeError, payload, done);

--- a/actions/loadDeck.js
+++ b/actions/loadDeck.js
@@ -37,6 +37,11 @@ import log from './log/clog';
 export default function loadDeck(context, payload, done) {
     log.info(context); // do not remove such log messages. If you don't want to see them, change log level in config
     context.dispatch('UPDATE_MODE', {mode: 'loading'});
+
+    // resets the deck view store
+    // TODO (what other store to reset ???)
+    context.dispatch('LOAD_DECK_CONTENT_START');
+
     if (!(AllowedPattern.DECK_ID.test(payload.params.id))) {
         context.executeAction(deckIdTypeError, payload, done);
         return;

--- a/actions/loadDeckView.js
+++ b/actions/loadDeckView.js
@@ -16,8 +16,7 @@ export default function loadDeckView(context, payload, done) {
 
     context.service.read('deck.content', payload, {timeout: 20 * 1000}, (err, res) => {
         if (err) {
-            console.log(err);
-            log.error(context, {filepath: __filename});
+            log.error(context, {filepath: __filename, message: err.message });
             context.executeAction(serviceUnavailable, payload, done);
             return;
         } else {

--- a/actions/loadLegacy.js
+++ b/actions/loadLegacy.js
@@ -10,7 +10,7 @@ export default function loadLegacy(context, payload, done) {
             context.executeAction(serviceUnavailable, payload, done);
             //context.dispatch('LOAD_FEATURED_FAILURE', err);
         } else {
-            done({'statusCode':'301','redirectURL': '/deck/' + res.new_id});
+            done({'statusCode': 301,'redirectURL': '/deck/' + res.new_id});
         }
     });
 }

--- a/actions/translation/loadNodeTranslations.js
+++ b/actions/translation/loadNodeTranslations.js
@@ -6,8 +6,8 @@ export default function loadNodeTranslations(context, payload, done) {
 
     context.service.read('decktree.nodetranslation', payload, {timeout: 20 * 1000}, (err, res) => {
         if (err) {
-            log.error(context, {filepath: __filename});
-            context.executeAction(serviceUnavailable, payload, done);
+            log.error(context, {filepath: __filename, message: err.message});
+            done(err);
         } else {
             context.dispatch('LOAD_TRANSLATIONS_SUCCESS', res);
             done();

--- a/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideViewPanel.js
@@ -50,7 +50,7 @@ class SlideViewPanel extends React.Component {
                 deckTheme = this.props.DeckTreeStore.theme;
             }
         }
-        if (this.currentID === selector.sid){
+        if (this.currentID === selector.sid && this.props.SlideViewStore.slideId) {
             let hideSpeakerNotes = true;
             if (this.props.SlideViewStore.speakernotes !== '' && this.props.SlideViewStore.speakernotes !== ' '){hideSpeakerNotes = false;}
 
@@ -73,8 +73,7 @@ class SlideViewPanel extends React.Component {
         };
         return (
             <div className="ui bottom attached segment">
-                {(this.currentID !== selector.sid) ? <div style={loadStyle} className="ui active dimmer"><div className="ui text loader">Loading</div></div> : ''}
-                {this.slideContentView}
+                {this.slideContentView || <div style={loadStyle} className="ui active dimmer"><div className="ui text loader">Loading</div></div>}
             </div>
         );
     }

--- a/components/Deck/DeckLandingPage.js
+++ b/components/Deck/DeckLandingPage.js
@@ -4,6 +4,7 @@ import { NavLink } from 'fluxible-router';
 import { Grid, Divider, Button, Header, Image, Icon, Item, Label, Menu, Segment, Container } from 'semantic-ui-react';
 
 import { connectToStores } from 'fluxible-addons-react';
+import ContentStore from '../../stores/ContentStore';
 import DeckPageStore from '../../stores/DeckPageStore';
 import DeckViewStore from '../../stores/DeckViewStore';
 import ContentLikeStore from '../../stores/ContentLikeStore';
@@ -55,8 +56,170 @@ class DeckLandingPage extends React.Component {
         return presLocation;
     }
 
+    getPlaceholder() {
+        return (
+            <Container fluid>
+                <Divider hidden/>
+                <Grid padded='vertically' divided='vertically' stackable>
+                    <Grid.Column only="tablet computer" tablet={1} computer={2}>
+                    </Grid.Column>
+
+                    <Grid.Column mobile={16} tablet={14} computer={12}>
+                        <Grid.Row>
+                            <Segment>
+                                <Grid stackable>
+                                    <Grid.Column width={4}>
+                                        <div className="ui placeholder">
+                                            <div className="rectangular image"></div>
+                                        </div>
+                                    </Grid.Column>
+                                    <Grid.Column width={12}>
+                                        <Grid.Row>
+                                            <div className="ui placeholder">
+                                                <div className="header">
+                                                    <div className="long line"></div>
+                                                    <div className="long line"></div>
+                                                </div>
+                                            </div>
+                                        </Grid.Row>
+                                        <Divider hidden />
+                                        <Grid stackable>
+                                            <Grid.Row columns={2}>
+                                                <Grid.Column>
+                                                    <div className="ui placeholder">
+                                                        <div className="line"></div>
+                                                        <div className="line"></div>
+                                                        <div className="line"></div>
+                                                    </div>
+                                                </Grid.Column>
+                                                <Grid.Column>
+                                                    <div className="ui placeholder">
+                                                        <div className="line"></div>
+                                                        <div className="line"></div>
+                                                    </div>
+                                                </Grid.Column>
+                                            </Grid.Row>
+                                            <Divider hidden />
+                                            <Grid.Row>
+                                                <Grid.Column>
+                                                    <div className="ui placeholder">
+                                                        <div className="header">
+                                                            <div className="line"></div>
+                                                        </div>
+                                                        <div className="paragraph">
+                                                            <div className="line"></div>
+                                                            <div className="line"></div>
+                                                        </div>
+                                                    </div>
+                                                </Grid.Column>
+                                            </Grid.Row>
+                                            <Divider hidden />
+                                            <Grid.Row>
+                                                <Grid.Column>
+                                                    <div className="ui placeholder">
+                                                        <div className="header">
+                                                            <div className="line"></div>
+                                                        </div>
+                                                        <div className="paragraph">
+                                                            <div className="line"></div>
+                                                        </div>
+                                                    </div>
+                                                </Grid.Column>
+                                            </Grid.Row>
+                                        </Grid>
+                                    </Grid.Column>
+                                </Grid>
+                            </Segment>
+                        </Grid.Row>
+                        <Grid.Row>
+                            <div className="ui bottom attached tabular menu" style={{'background': '#e0e1e2'}}>
+                                <div className="ui icon buttons huge attached">
+                                    <Button icon size="huge">
+                                        <Icon name="line graph" />
+                                    </Button>
+                                    <Button icon size="huge">
+                                        <Icon name="warning circle" />
+                                    </Button>
+                                </div>
+
+                                <div className="right inverted menu">
+                                    <div className="ui icon buttons huge attached">
+                                        <Button icon size="huge">
+                                            <Icon name="open folder" />
+                                        </Button>
+                                        <Button icon size="huge">
+                                            <Icon name="play circle" />
+                                        </Button>
+                                        <Button icon size="huge">
+                                            <Icon name="record" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            </div>
+                        </Grid.Row>
+
+                        <Divider hidden />
+
+                        <Grid divided='vertically' stackable>
+                            <Grid.Column only="tablet computer" width={12}>
+                                <Segment attached='top' >
+                                    <div className="ui placeholder">
+                                        <div className="header">
+                                            <div className="line"></div>
+                                        </div>
+                                        <div className="paragraph">
+                                            <div className="long line"></div>
+                                        </div>
+                                    </div>
+                                </Segment>
+                                <Segment attached>
+                                    <div className="ui placeholder">
+                                        <div className="header">
+                                            <div className="line"></div>
+                                        </div>
+                                        <div className="paragraph">
+                                            <div className="long line"></div>
+                                        </div>
+                                    </div>
+                                </Segment>
+                                <Segment attached='bottom'>
+                                    <div className="ui placeholder">
+                                        <div className="header">
+                                            <div className="line"></div>
+                                        </div>
+                                        <div className="paragraph">
+                                            <div className="long line"></div>
+                                        </div>
+                                    </div>
+                                </Segment>
+                            </Grid.Column>
+                            <Grid.Column only="tablet computer" width={4}>
+                                <Segment>
+                                    <div className="ui fluid placeholder">
+                                    </div>
+                                </Segment>
+                                <Segment attached='bottom'>
+                                    <a href='https://creativecommons.org/licenses/by-sa/4.0/' target='_blank'>
+                                        <CCBYSA size='small' />
+                                    </a>
+                                    This work is licensed under <a href='https://creativecommons.org/licenses/by-sa/4.0/' target='_blank'>Creative Commons Attribution-ShareAlike 4.0 International License</a>
+                                </Segment>
+                            </Grid.Column>
+                        </Grid>
+
+                    </Grid.Column>
+
+                    <Grid.Column only="tablet computer" tablet={1} computer={2}>
+                    </Grid.Column>
+
+                </Grid>
+            </Container>
+        );
+    }
+
     render() {
         let deckData = this.props.DeckViewStore.deckData;
+        if (lodash.isEmpty(deckData)) return this.getPlaceholder();
 
         let firstSlide = (this.props.DeckViewStore.slidesData && this.props.DeckViewStore.slidesData.children && this.props.DeckViewStore.slidesData.children[0]);
         const totalSlides = lodash.get(this.props.DeckViewStore.slidesData, 'children.length', undefined);
@@ -296,8 +459,17 @@ class DeckLandingPage extends React.Component {
     }
 }
 
-DeckLandingPage = connectToStores(DeckLandingPage, [ContentLikeStore, DeckPageStore, DeckViewStore, TranslationStore, ContentModulesStore, SimilarContentStore], (context, props) => {
+DeckLandingPage = connectToStores(DeckLandingPage, [
+    ContentStore,
+    ContentLikeStore,
+    DeckPageStore,
+    DeckViewStore,
+    TranslationStore,
+    ContentModulesStore,
+    SimilarContentStore,
+], (context, props) => {
     return {
+        ContentStore: context.getStore(ContentStore).getState(),
         ContentLikeStore: context.getStore(ContentLikeStore).getState(),
         DeckPageStore: context.getStore(DeckPageStore).getState(),
         DeckViewStore: context.getStore(DeckViewStore).getState(),

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -409,11 +409,16 @@ export default {
                     context.executeAction(loadDeckStats, {deckId: payload.params.id}, callback);
                 }],
                 (err, result) => {
-                    if(err)console.log(err);
+                    if (err) {
+                        if (err.statusCode === 404) {
+                            return context.executeAction(notFoundError, payload, done);
+                        } else {
+                            return context.executeAction(serviceUnavailable, payload, done);
+                        }
+                    }
                     done();
                 }
             );
-
         }
     },
 
@@ -676,12 +681,18 @@ export default {
                     payload.params.sid = payload.params.slideID;//needs to be reset for loadPresentation
                     payload.params.language = payload.query.language;
                     context.executeAction(loadPresentation, payload, callback);
-                },
+                }],
                 (err, result) => {
-                    if(err) console.log(err);
+                    if (err) {
+                        if (err.statusCode === 404) {
+                            return context.executeAction(notFoundError, payload, done);
+                        } else {
+                            return context.executeAction(serviceUnavailable, payload, done);
+                        }
+                    }
                     done();
                 }
-            ]);
+            );
         }
     },
     presentationIE: {
@@ -703,12 +714,18 @@ export default {
                     // adding language to the params
                     payload.params.language = payload.query.language;
                     context.executeAction(loadPresentation, payload, callback);
-                },
+                }],
                 (err, result) => {
-                    if(err) console.log(err);
+                    if (err) {
+                        if (err.statusCode === 404) {
+                            return context.executeAction(notFoundError, payload, done);
+                        } else {
+                            return context.executeAction(serviceUnavailable, payload, done);
+                        }
+                    }
                     done();
                 }
-            ]);
+            );
         }
     },
     print: {
@@ -734,12 +751,18 @@ export default {
                     // adding language to the params
                     payload.params.language = payload.query.language;
                     context.executeAction(loadPresentation, payload, callback);
-                },
+                }],
                 (err, result) => {
-                    if(err) console.log(err);
+                    if (err) {
+                        if (err.statusCode === 404) {
+                            return context.executeAction(notFoundError, payload, done);
+                        } else {
+                            return context.executeAction(serviceUnavailable, payload, done);
+                        }
+                    }
                     done();
                 }
-            ]);
+            );
         }
     },
     oldSlugPresentation: {

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -23,6 +23,7 @@ import loadImportFile from '../actions/loadImportFile';
 import loadPresentation from '../actions/loadPresentation';
 import loadAddDeck from '../actions/loadAddDeck';
 import notFoundError from '../actions/error/notFoundError';
+import serviceUnavailable from '../actions/error/serviceUnavailable';
 import loadResetPassword from '../actions/loadResetPassword';
 import async from 'async';
 import { chooseAction } from '../actions/user/userprofile/chooseAction';
@@ -381,7 +382,16 @@ export default {
         handler: require('../components/Deck/DeckLandingPage'),
         page: 'decklandingpage',
         action: (context, payload, done) => {
-            context.executeAction(loadDeck, payload, done);
+            context.executeAction(loadDeck, payload, (err) => {
+                if (err) {
+                    if (err.statusCode === 404) {
+                        return context.executeAction(notFoundError, payload, done);
+                    } else {
+                        return context.executeAction(serviceUnavailable, payload, done);
+                    }
+                }
+                done();
+            });
         }
     },
 
@@ -397,12 +407,12 @@ export default {
                 },
                 (callback) => {
                     context.executeAction(loadDeckStats, {deckId: payload.params.id}, callback);
-                },
+                }],
                 (err, result) => {
-                    if(err) console.log(err);
+                    if(err)console.log(err);
                     done();
                 }
-            ]);
+            );
 
         }
     },
@@ -448,7 +458,7 @@ export default {
             ];
             urlParts = urlParts.filter((u) => !!u);
 
-            done({statusCode: '301', redirectURL: urlParts.join('/')});
+            done({statusCode: 301, redirectURL: urlParts.join('/')});
         },
     },
     legacydeck: {
@@ -735,7 +745,7 @@ export default {
             ];
             urlParts = urlParts.filter((u) => !!u);
 
-            done({statusCode: '301', redirectURL: urlParts.join('/')});
+            done({statusCode: 301, redirectURL: urlParts.join('/')});
         },
     },
     neo4jguide: {
@@ -760,7 +770,7 @@ export default {
             ];
             urlParts = urlParts.filter((u) => !!u);
 
-            done({statusCode: '301', redirectURL: urlParts.join('/')});
+            done({statusCode: 301, redirectURL: urlParts.join('/')});
         },
     },
     importfile: {

--- a/configs/routes.js
+++ b/configs/routes.js
@@ -439,7 +439,17 @@ export default {
                 }
             }
 
-            context.executeAction(loadDeck, payload, done);
+            context.executeAction(loadDeck, payload, (err) => {
+                if (err) {
+                    // check for either 404 or 422. 422 is returned from deck service when the deck/slide combo do not match
+                    if (err.statusCode === 404 || err.statusCode === 422) {
+                        return context.executeAction(notFoundError, payload, done);
+                    } else {
+                        return context.executeAction(serviceUnavailable, payload, done);
+                    }
+                }
+                done();
+            });
         }
     },
 

--- a/server/handleServerRendering.js
+++ b/server/handleServerRendering.js
@@ -120,26 +120,25 @@ export default function handleServerRendering(req, res, next){
                 reqId: req.reqId
             }, (err) => {
                 if (err) {
-                    if (err.statusCode && err.statusCode === '301') {
-                        //console.log('REDIRECTING to '+ JSON.stringify(err));
+                    if (err.statusCode === 301) {
                         res.redirect(301, err.redirectURL);
-                    }else
-                    if (err.statusCode && err.statusCode === '404') {
+                    } else if (err.statusCode) {
+                        // render page and also set status to the error code
                         let html = renderApp(req, res, context);
                         debug('Sending markup');
                         res.type('html');
                         res.status(err.statusCode);
                         log.error({Id: res.reqId, URL: req.url, StatusCode: res.statusCode, StatusMessage: res.statusMessage, Message: 'Sending response'});
+                        res.write('<!DOCTYPE html>' + html);
                         res.end();
-                        return;
-                    }else{
+                    } else {
+                        // TODO render page even though there was an error ????
                         let html = renderApp(req, res, context);
                         debug('Sending markup');
                         res.type('html');
                         res.write('<!DOCTYPE html>' + html);
                         log.error({Id: res.reqId, URL: req.url, StatusCode: res.statusCode, StatusMessage: res.statusMessage, Message: 'Sending response'});
                         res.end();
-                        return;
                     }
 
                 } else {

--- a/services/deck.js
+++ b/services/deck.js
@@ -225,6 +225,8 @@ export default {
                     return userPromisesMap[user] = userPromisesMap[user] || rp.get({
                         uri: Microservices.user.uri + '/user/' + user.toString(),
                         json: true,
+                    }).catch((err) => {
+                        // ignore this for now, return nothing
                     });
                 });
                 return Promise.all(userPromises);
@@ -252,8 +254,8 @@ export default {
                 callback(null, {
                     deckData,
                     slidesData,
-                    creatorData: usersData[0],
-                    ownerData: usersData[1],
+                    creatorData: usersData[0] || {},
+                    ownerData: usersData[1] || {},
                     originCreatorData: usersData[2] || {},
                 });
             }).catch((err) => {

--- a/services/decktree.js
+++ b/services/decktree.js
@@ -30,8 +30,7 @@ export default {
             }).then((res) => {
                 callback(null, {translations: res, selector: selector, language: args.language});
             }).catch((err) => {
-                console.log(err);
-                callback(null, {translations: [], selector: selector, language: args.language});
+                callback(err);
             });
         }
 

--- a/stores/DeckViewStore.js
+++ b/stores/DeckViewStore.js
@@ -69,7 +69,7 @@ class DeckViewStore extends BaseStore {
 
 DeckViewStore.storeName = 'DeckViewStore';
 DeckViewStore.handlers = {
-    'LOAD_DECK_CONTENT_START': 'resetContent',
+    'LOAD_DECK_PAGE_START': 'resetContent',
     'LOAD_DECK_CONTENT_SUCCESS': 'updateContent',
     'UPDATE_DECK_VIEW_PANEL_HEIGHT': 'updateDeckViewPanelHeight',
     'INCREMENT_DECK_VIEW_COUNTER': 'incrementDeckViewCounter'

--- a/stores/DeckViewStore.js
+++ b/stores/DeckViewStore.js
@@ -34,6 +34,16 @@ class DeckViewStore extends BaseStore {
         this.emitChange();
     }
 
+    resetContent() {
+        this.deckData = {};
+        this.slidesData = {};
+        this.creatorData = {};
+        this.ownerData = {};
+        this.originCreatorData = {};
+        this.deckViewPanelHeight = 450;
+        this.emitChange();
+    }
+
     getState() {
         return {
             deckData: this.deckData,
@@ -59,6 +69,7 @@ class DeckViewStore extends BaseStore {
 
 DeckViewStore.storeName = 'DeckViewStore';
 DeckViewStore.handlers = {
+    'LOAD_DECK_CONTENT_START': 'resetContent',
     'LOAD_DECK_CONTENT_SUCCESS': 'updateContent',
     'UPDATE_DECK_VIEW_PANEL_HEIGHT': 'updateDeckViewPanelHeight',
     'INCREMENT_DECK_VIEW_COUNTER': 'incrementDeckViewCounter'

--- a/stores/SlideViewStore.js
+++ b/stores/SlideViewStore.js
@@ -13,6 +13,16 @@ class SlideViewStore extends BaseStore {
         this.scaleRatio = null;
     }
 
+    resetContent() {
+        this.id = '';
+        this.slideId = '';
+        this.title = '';
+        this.content = '';
+        this.speakernotes = '';
+        this.tags = [];
+        this.emitChange();
+    }
+
     updateContent(payload) {
         //this.id = payload.slide.id;
         this.slideId = payload.selector.sid;
@@ -74,6 +84,7 @@ class SlideViewStore extends BaseStore {
 
 SlideViewStore.storeName = 'SlideViewStore';
 SlideViewStore.handlers = {
+    'LOAD_DECK_PAGE_START': 'resetContent',
     'LOAD_SLIDE_CONTENT_SUCCESS': 'updateContent',
     'ZOOM': 'zoomContent'
 };


### PR DESCRIPTION
This mainly fixes the deck not found page for landing and deck view pages.

Related to [SWIK-1737](https://slidewiki.atlassian.net/browse/SWIK-1737) as it fixes one part of it: show an error message, but does not include the part about informing users the deck was removed.

Also fixes [SWIK-2526](https://slidewiki.atlassian.net/browse/SWIK-2526), as well as improving some loading indicators when switching between nodes in deck view.