### PR TITLE
Fix IE syntax error problem 

### DIFF
--- a/components/common/SWAutoComplete.js
+++ b/components/common/SWAutoComplete.js
@@ -178,7 +178,7 @@ class SWAutoComplete extends React.Component {
                                                 {itemToString(item)}
                                             </Item>
                                         ))
-                                        : null}
+                                        : <span></span>}
                                 </BaseMenu>
                             </div>
                         </div>

--- a/components/common/SWAutocompleteShared.js
+++ b/components/common/SWAutocompleteShared.js
@@ -181,29 +181,6 @@ function filterItems(filter, items) {
         : items;
 }
 
-function getStringItems(filter) {
-    return getItems(filter).map(({name}) => name);
-}
-
-/*function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}*/
-
-/*
-This function is causing problems in browsers that don't support ES6 (e.g. IE)
-
-async function getItemsAsync(filter, {reject}) {
-    await sleep(Math.random() * 2000);
-    if (reject) {
-        // this is just so we can have examples that show what happens
-        // when there's a request failure.
-        throw new Error({error: 'request rejected'});
-    }
-    return getItems(filter);
-}*/
-
 const itemToString = (i) => (i ? i.name : '');
 
 export {
@@ -218,7 +195,5 @@ export {
     css,
     itemToString,
     getItems,
-    getStringItems,
-    //getItemsAsync,
     filterItems
 };

--- a/components/common/SWAutocompleteShared.js
+++ b/components/common/SWAutocompleteShared.js
@@ -185,11 +185,14 @@ function getStringItems(filter) {
     return getItems(filter).map(({name}) => name);
 }
 
-function sleep(ms) {
+/*function sleep(ms) {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);
     });
-}
+}*/
+
+/*
+This function is causing problems in browsers that don't support ES6 (e.g. IE)
 
 async function getItemsAsync(filter, {reject}) {
     await sleep(Math.random() * 2000);
@@ -199,7 +202,7 @@ async function getItemsAsync(filter, {reject}) {
         throw new Error({error: 'request rejected'});
     }
     return getItems(filter);
-}
+}*/
 
 const itemToString = (i) => (i ? i.name : '');
 
@@ -216,6 +219,6 @@ export {
     itemToString,
     getItems,
     getStringItems,
-    getItemsAsync,
+    //getItemsAsync,
     filterItems
 };


### PR DESCRIPTION
I have commented out some ES6 code that breaks SlideWiki in Internet Explorer. As far as I have seen, the code is not used by other components. 