### PR TITLE
Fix error when language is null

### DIFF
--- a/stores/TranslationStore.js
+++ b/stores/TranslationStore.js
@@ -89,7 +89,7 @@ class TranslationStore extends BaseStore {
 
     deckTreeGotLoaded(data) {
         this.treeLanguage = data.deckTree.variants.find((v) => v.original).language;
-        this.treeTranslations = data.deckTree.variants.filter((v) => !v.original).map((cur) => cur.language.substring(0, 2));
+        this.treeTranslations = data.deckTree.variants.filter((v) => !v.original && v.language !== null).map((cur) => cur.language.substring(0, 2));
 
         this.emitChange();
         // this.logState('deckTreeGotLoaded');


### PR DESCRIPTION
The caused for some slide decks a 504 error on page load, since an exception was thrown.

E.g. this deck cannot be loaded right now: https://slidewiki.org/deck/584 The page is rendered at the server-side, but because there is an exception, the page stops loading. After 60 seconds a 504 Gateway Time-out error will appear. 