### PR TITLE
Set specific version of intl-locales-supported package

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "immutable": "^3.8.1",
     "install": "^0.10.1",
     "intl": "^1.2.5",
-    "intl-locales-supported": "^1.0.0",
+    "intl-locales-supported": "1.0.0",
     "iso-639-1": "^1.3.0",
     "jquery": "^3.1.1",
     "jquery-contextmenu": "^2.4.5",


### PR DESCRIPTION
The package `intl-locales-supported` breaks SlideWiki because the newer version is not compatible anymore (although it should be!)

This is now fixed by specifying the exact version number. 