### PR TITLE
1184 dynamic question adding

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionAdd.js
+++ b/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionAdd.js
@@ -26,16 +26,8 @@ class ContentQuestionAdd extends React.Component {
         this.updateQuestionDifficulty = this.updateQuestionDifficulty.bind(this);
         /* update answers */
         this.updateAnswer = this.updateAnswer.bind(this);
-        this.updateAnswer1 = this.updateAnswer1.bind(this);
-        this.updateAnswer2 = this.updateAnswer2.bind(this);
-        this.updateAnswer3 = this.updateAnswer3.bind(this);
-        this.updateAnswer4 = this.updateAnswer4.bind(this);
         /* update correct answer choice */
         this.updateCorrect = this.updateCorrect.bind(this);
-        this.updateCorrect1 = this.updateCorrect1.bind(this);
-        this.updateCorrect2 = this.updateCorrect2.bind(this);
-        this.updateCorrect3 = this.updateCorrect3.bind(this);
-        this.updateCorrect4 = this.updateCorrect4.bind(this);
 
         this.addAnswerClick = this.addAnswerClick.bind(this);
         this.removeAnswerClick = this.removeAnswerClick.bind(this);
@@ -144,45 +136,12 @@ class ContentQuestionAdd extends React.Component {
         this.setState({answers:tmp_array});
     }
 
-    updateAnswer1(e) {
-        this.setState({answer1: e.target.value});
-    }
-
-    updateAnswer2(e) {
-        this.setState({answer2: e.target.value});
-    }
-
-    updateAnswer3(e) {
-        this.setState({answer3: e.target.value});
-    }
-
-    updateAnswer4(e) {
-        //console.log(e.target.value);
-        this.setState({answer4: e.target.value});
-    }
-
+    /* Update correct choice among available answer choices */
     updateCorrect(e) {
         const tmp_array = [...this.state.corrects];
         let indexShouldBeChanged = this.getItemId(e.target.id, 'answer');
         tmp_array[indexShouldBeChanged] = e.target.checked;
         this.setState({corrects:tmp_array});
-    }
-
-    /* Update correct choice among available answer choices */
-    updateCorrect1(e) {
-        this.setState({correct1: e.target.checked});
-    }
-
-    updateCorrect2(e) {
-        this.setState({correct2: e.target.checked});
-    }
-
-    updateCorrect3(e) {
-        this.setState({correct3: e.target.checked});
-    }
-
-    updateCorrect4(e) {
-        this.setState({correct4: e.target.checked});
     }
 
     updateExplanation(e) {
@@ -206,19 +165,13 @@ class ContentQuestionAdd extends React.Component {
         const answerChoiceWidth = {
             width: '680px',
         };
-        console.log(this.state.answers);
         let answers = this.state.answers.map((item, index) =>
         <div className="inline field">
             <div className="ui checkbox">
-                <input  type="checkbox" name={'example' + (index+1)} id={'answer' + (index+1)} tabIndex="0" className="hidden" onChange={this.updateCorrect}/>
+                <input  type="checkbox" name={'example' + (index+1)} checked={this.state.corrects[index]?'checked':''} id={'answer' + (index+1)} tabIndex="0" className="hidden" onChange={this.updateCorrect}/>
                 <label htmlFor={'answer' + (index+1)}></label>
             </div>
-            <button type="button" id={'remove' + (index+1)} className="ui secondary labeled close icon button" onClick={this.removeAnswerClick}>
-                    <i className="icon close" />
-                    <FormattedMessage
-                        id='ContentQuestionAdd.form.button_remove'
-                        defaultMessage='Remove' />
-            </button>
+            <i id={'remove' + (index+1)} onClick={this.removeAnswerClick} className="ui delete icon" />
             <input style={answerChoiceWidth} type="text" value={item} name={'response' + (index+1)} id={'response' + (index+1)} onChange={this.updateAnswer}/>
             <label htmlFor={'response' + (index+1)}></label>
         </div>
@@ -286,39 +239,7 @@ class ContentQuestionAdd extends React.Component {
                                         id='ContentQuestionAdd.form.answer_choices'
                                         defaultMessage='Answer Choices' />
                                 </legend>
-                                {/* <div className="inline field">
-                                    <div className="ui checkbox">
-                                        <input type="checkbox" name="example1" id="answer1" tabIndex="0" className="hidden" onChange={this.updateCorrect1}/>
-                                        <label htmlFor="answer1"></label>
-                                    </div>
-                                    <input style={answerChoiceWidth} type="text" name="response1" id="response1" onChange={this.updateAnswer1}/>
-                                    <label htmlFor="response1"></label>
-                                </div> */}
                                 {answers}
-                                {/* <div className="inline field">
-                                    <div className="ui checkbox">
-                                        <input  type="checkbox" name="example2" id="answer2" tabIndex="0" className="hidden" onChange={this.updateCorrect2}/>
-                                        <label htmlFor="answer2"></label>
-                                    </div>
-                                    <input style={answerChoiceWidth} type="text" name="response2" id="response2" onChange={this.updateAnswer2}/>
-                                    <label htmlFor="response2"></label>
-                                </div> */}
-                                {/* <div className="inline field">
-                                    <div className="ui checkbox">
-                                        <input type="checkbox" name="example3" id="answer3" tabIndex="0" className="hidden" onChange={this.updateCorrect3}/>
-                                        <label htmlFor="answer3"></label>
-                                    </div>
-                                    <input type="text" style={answerChoiceWidth} name="response3" id="response3" onChange={this.updateAnswer3}/>
-                                    <label htmlFor="response3"></label>
-                                </div>
-                                <div className="inline field">
-                                    <div className="ui checkbox">
-                                        <input type="checkbox" name="example4" id="answer4" tabIndex="0" className="hidden" onChange={this.updateCorrect4}/>
-                                        <label htmlFor="answer4"></label>
-                                    </div>
-                                    <input type="text" style={answerChoiceWidth} name="response4" id="response4" onChange={this.updateAnswer4}/>
-                                    <label htmlFor="response4"></label>
-                                </div> */}
                                 <button type="button" className="ui right floated compact button primary" onClick={this.addAnswerClick} >
                                         <i className="small plus icon" />
                                         <FormattedMessage

--- a/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionEdit.js
+++ b/components/Deck/ContentModulesPanel/ContentQuestionsPanel/ContentQuestionEdit.js
@@ -109,12 +109,12 @@ class ContentQuestionEdit extends React.Component {
             }
         });
         swal({
-            title: context.intl.formatMessage(swal_messages.text),
+            title: this.context.intl.formatMessage(swal_messages.text),
             type: 'warning',
             showCancelButton: true,
             confirmButtonColor: '#3085d6',
             cancelButtonColor: '#d33',
-            confirmButtonText: context.intl.formatMessage(swal_messages.confirmButtonText),
+            confirmButtonText: this.context.intl.formatMessage(swal_messages.confirmButtonText),
         }).then((accepted) => {
             this.context.executeAction(deleteQuestion, {questionId: this.state.qid});
         }, (reason) => {/*do nothing*/}).catch(swal.noop);

--- a/services/questions.js
+++ b/services/questions.js
@@ -70,19 +70,12 @@ export default {
         req.reqId = req.reqId ? req.reqId : -1;
         log.info({Id: req.reqId, Service: __filename.split('/').pop(), Resource: resource, Operation: 'create', Method: req.method});
         let args = params.params? params.params : params;
-
+        
         let choices = [];
-        if (args.question.answer1 !== '') {
-            choices.push({'choice': args.question.answer1, 'is_correct': args.question.correct1});
-        }
-        if (args.question.answer2 !== '') {
-            choices.push({'choice': args.question.answer2, 'is_correct': args.question.correct2});
-        }
-        if (args.question.answer3 !== '') {
-            choices.push({'choice': args.question.answer3, 'is_correct': args.question.correct3});
-        }
-        if (args.question.answer4 !== '') {
-            choices.push({'choice': args.question.answer4, 'is_correct': args.question.correct4});
+        for(let i = 0; i < args.question.answers.length; i++) {
+            if (args.question.answers[i] !== '') {
+                choices.push({'choice': args.question.answers[i], 'is_correct': args.question.corrects[i]});
+            }
         }
 
         if (resource === 'questions.add') {

--- a/services/questions.js
+++ b/services/questions.js
@@ -118,21 +118,11 @@ export default {
         if (resource === 'questions.update') {
             let choices = [];
             let answers = [];//There is a problem with different names used on the platform and service
-            if (args.question.answer1 !== '') {
-                choices.push({'choice': args.question.answer1, 'is_correct': args.question.correct1});
-                answers.push({'answer': args.question.answer1, 'correct': args.question.correct1});
-            }
-            if (args.question.answer2 !== '') {
-                choices.push({'choice': args.question.answer2, 'is_correct': args.question.correct2});
-                answers.push({'answer': args.question.answer2, 'correct': args.question.correct2});
-            }
-            if (args.question.answer3 !== '') {
-                choices.push({'choice': args.question.answer3, 'is_correct': args.question.correct3});
-                answers.push({'answer': args.question.answer3, 'correct': args.question.correct3});
-            }
-            if (args.question.answer4 !== '') {
-                choices.push({'choice': args.question.answer4, 'is_correct': args.question.correct4});
-                answers.push({'answer': args.question.answer4, 'correct': args.question.correct4});
+            for(let i = 0; i < args.question.answers.length; i++) {
+                if (args.question.answers[i] !== '') {
+                    choices.push({'choice': args.question.answers[i], 'is_correct': args.question.corrects[i]});
+                    answers.push({'answer': args.question.answers[i], 'correct': args.question.corrects[i]});
+                }
             }
 
             rp.put({


### PR DESCRIPTION
Previously, users can't add answers dynamically. But now, in the question Add/Edit panel, users can add/remove answers in a dynamic way.
So, the number of answers starts from 2 and it can be increased up to whatever users want. It should be mentioned that according to the current version of our backend service for adding/editing questions, more than 4 answers is prevented. So, we should update the backend service as well.
Finally, we have a problem with deleting questions which has been handled in this branch.