### PR TITLE
1204 - access-keys in slide-view have been added.

### DIFF
--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -75,11 +75,11 @@ class ContentActionsFooter extends React.Component {
         let userAgent = window.navigator.userAgent;
         let mobile = new MobileDetect(userAgent);
         this.setState({isMobile: (mobile.phone() !== null) ? true : false});
-        document.addEventListener("keydown", this.handleKeyDown);        
+        document.addEventListener('keydown', this.handleKeyDown);        
     }
 
     componentWillUnmount() {
-        document.removeEventListener("keydown", this.handleKeyDown)
+        document.removeEventListener('keydown', this.handleKeyDown);
     }
 
     handleExpandClick(){
@@ -172,8 +172,8 @@ class ContentActionsFooter extends React.Component {
     }
 
     handleKeyDown = (e) => {
-        if (e.altKey && e.key === "s") {         
-            window.open(makeNodeURL(this.props.ContentStore.selector, 'presentation', undefined, this.props.deckSlug, this.props.TranslationStore.currentLang), "_blank")
+        if (e.altKey && e.keyCode === 83) { //s    
+            window.open(makeNodeURL(this.props.ContentStore.selector, 'presentation', undefined, this.props.deckSlug, this.props.TranslationStore.currentLang), '_blank');
         }
     }
 

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsFooter.js
@@ -75,6 +75,11 @@ class ContentActionsFooter extends React.Component {
         let userAgent = window.navigator.userAgent;
         let mobile = new MobileDetect(userAgent);
         this.setState({isMobile: (mobile.phone() !== null) ? true : false});
+        document.addEventListener("keydown", this.handleKeyDown);        
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.handleKeyDown)
     }
 
     handleExpandClick(){
@@ -163,6 +168,12 @@ class ContentActionsFooter extends React.Component {
                 userId: this.props.UserProfileStore.userid,
                 followed_type: 'deck'
             });
+        }
+    }
+
+    handleKeyDown = (e) => {
+        if (e.altKey && e.key === "s") {         
+            window.open(makeNodeURL(this.props.ContentStore.selector, 'presentation', undefined, this.props.deckSlug, this.props.TranslationStore.currentLang), "_blank")
         }
     }
 

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
@@ -107,11 +107,11 @@ class ContentActionsHeader extends React.Component {
 
     componentDidMount() {
         this.setState({ windowInnerWidth: window.innerWidth });
-        document.addEventListener("keydown", this.handleKeyDown);
+        document.addEventListener('keydown', this.handleKeyDown);
     }
 
     componentWillUnmount() {
-        document.removeEventListener("keydown", this.handleKeyDown)
+        document.removeEventListener('keydown', this.handleKeyDown);
     }
 
     handleAddNode(selector, nodeSpec) {
@@ -203,8 +203,8 @@ class ContentActionsHeader extends React.Component {
     handleKeyDown = (e) => {
         let selectorImm = this.props.DeckTreeStore.selector;
         let selector = { id: selectorImm.get('id'), stype: selectorImm.get('stype'), sid: selectorImm.get('sid'), spath: selectorImm.get('spath') };        
-        if (e.altKey && e.key === "w") {         
-            this.handleEditButton(selector)
+        if (e.altKey && e.keyCode === 87) { //w    
+            this.handleEditButton(selector);
         }
     }
 

--- a/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
+++ b/components/Deck/ContentPanel/ContentActions/ContentActionsHeader.js
@@ -107,8 +107,12 @@ class ContentActionsHeader extends React.Component {
 
     componentDidMount() {
         this.setState({ windowInnerWidth: window.innerWidth });
+        document.addEventListener("keydown", this.handleKeyDown);
     }
 
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.handleKeyDown)
+    }
 
     handleAddNode(selector, nodeSpec) {
         if (this.props.TranslationStore.currentLang) {
@@ -193,6 +197,14 @@ class ContentActionsHeader extends React.Component {
             this.context.executeAction(navigateAction, {
                 url: nodeURL
             });
+        }
+    }
+
+    handleKeyDown = (e) => {
+        let selectorImm = this.props.DeckTreeStore.selector;
+        let selector = { id: selectorImm.get('id'), stype: selectorImm.get('stype'), sid: selectorImm.get('sid'), spath: selectorImm.get('spath') };        
+        if (e.altKey && e.key === "w") {         
+            this.handleEditButton(selector)
         }
     }
 

--- a/components/Deck/ContentPanel/SlideModes/SlideControl.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideControl.js
@@ -16,14 +16,14 @@ class SlideControl extends React.Component {
     }
     componentDidMount() {
         this.updateProgressbar();
-        document.addEventListener("keydown", this.handleKeyDown);
+        document.addEventListener('keydown', this.handleKeyDown);
     }
     componentDidUpdate(){
         this.updateProgressbar();
     }
 
     componentWillUnmount() {
-        document.removeEventListener("keydown", this.handleKeyDown)
+        document.removeEventListener('keydown', this.handleKeyDown);
     }
 
     confirmLeaving = () => {
@@ -118,10 +118,11 @@ class SlideControl extends React.Component {
         let selector = this.props.DeckTreeStore.selector;
         let flatTree = this.props.DeckTreeStore.flatTree;
         let mode = this.props.mode;
-        if (e.altKey && e.key === "n") {         
-            this.handleNextClick(selector, flatTree, mode)
-        } else if (e.altKey && e.key === "p") {         
-            this.handlePreviousClick(selector, flatTree, mode)
+
+        if (e.altKey && e.keyCode === 78) { //n  
+            this.handleNextClick(selector, flatTree, mode);
+        } else if (e.altKey && e.keyCode === 80) { //p  
+            this.handlePreviousClick(selector, flatTree, mode);
         }
     }
 

--- a/components/Deck/ContentPanel/SlideModes/SlideControl.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideControl.js
@@ -16,9 +16,14 @@ class SlideControl extends React.Component {
     }
     componentDidMount() {
         this.updateProgressbar();
+        document.addEventListener("keydown", this.handleKeyDown);
     }
     componentDidUpdate(){
         this.updateProgressbar();
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener("keydown", this.handleKeyDown)
     }
 
     confirmLeaving = () => {
@@ -108,6 +113,18 @@ class SlideControl extends React.Component {
         $(progressbar).progress({percent: percentage});
         //$(progressbar).show();
     }
+
+    handleKeyDown = (e) => {
+        let selector = this.props.DeckTreeStore.selector;
+        let flatTree = this.props.DeckTreeStore.flatTree;
+        let mode = this.props.mode;
+        if (e.altKey && e.key === "n") {         
+            this.handleNextClick(selector, flatTree, mode)
+        } else if (e.altKey && e.key === "p") {         
+            this.handlePreviousClick(selector, flatTree, mode)
+        }
+    }
+
     render() {
         //hide focused outline
         let compStyle = {


### PR DESCRIPTION
The following access-keys have been added in the slide view:

- **Start presentation: Alt + s**  =>  in deck-page(/deck/...)  and slide-page(/slide/...)
- **Edit slide: Alt + w** => in deck-page(/deck/...)  and slide-page(/slide/...)
- **Next slide: Alt + n** => in slide-page(/slide/...)
- **Previous slide: Alt + p** => in slide-page(/slide/...)

They have been checked on Chrome and Firefox.
It should be mentioned that in Firefox, Start presentation shortcut open also history menu.

Fixes #1204