### PR TITLE
Fix wrong alignment of unsaved Markdown slides

### DIFF
--- a/components/Deck/ContentPanel/SlideModes/SlideEditPanel/MarkdownEditor.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideEditPanel/MarkdownEditor.js
@@ -265,7 +265,7 @@ class MarkdownEditor extends React.Component {
                     </div>
                     <div className="column" style={{boxShadow: 'rgba(0, 0, 0, 0.25) 0px 0px 12px', padding:0, margin: '0 20px'}}>
                         <SlideContentView content={this.props.title === this.state.title ? this.state.htmlContent: this.props.content}
-                        speakernotes='' hideSpeakerNotes={true} theme={deckTheme} hideBorder={true}/>
+                        speakernotes='' hideSpeakerNotes={true} theme={deckTheme} hideBorder={true} markdownEditorView={true} />
                     </div>
                   </div>
                 </div>

--- a/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideContentView.js
+++ b/components/Deck/ContentPanel/SlideModes/SlideViewPanel/SlideContentView.js
@@ -137,7 +137,7 @@ class SlideContentView extends React.Component {
             // for markdown slides, vertically align the content 
             const markdown = this.props.SlideEditStore.markdown;
             
-            if (markdown && markdown.length !== 0 && markdown.trim()) {
+            if (this.props.markdownEditorView || (markdown && markdown.length !== 0 && markdown.trim())) {
                 slideHTMLContent = '<div class="pptx2html" style="width: 960px; height:720px; position: relative; flex-direction: column; padding-left: 66px; flex-wrap: nowrap; align-items: stretch; display: flex; justify-content: center; line-height: 1.1">' + slideHTMLContent + '</div>';
             } else {
                 // for legacy slides without a pptx2html element 


### PR DESCRIPTION
Fixes a problem where newly created (unsaved) Markdown slides have a wrong alignment. For example:

![image](https://user-images.githubusercontent.com/1567948/79564591-41375980-80af-11ea-998f-b7f56ce3ebb2.png)

_(the text should be vertically aligned in the middle)_