### PR TITLE
fix: solve a problem with reverting slides

### DIFF
--- a/components/Deck/ContentModulesPanel/ContentHistoryPanel/ContentChangeItem.js
+++ b/components/Deck/ContentModulesPanel/ContentHistoryPanel/ContentChangeItem.js
@@ -29,13 +29,13 @@ class ContentChangeItem extends React.Component {
             }
         });
         swal({
-            text: context.intl.formatMessage(swal_messages.text),
+            text: this.context.intl.formatMessage(swal_messages.text),
             type: 'question',
             showCloseButton: true,
             showCancelButton: true,
-            confirmButtonText: context.intl.formatMessage(swal_messages.confirmButtonText),
+            confirmButtonText: this.context.intl.formatMessage(swal_messages.confirmButtonText),
             confirmButtonClass: 'ui olive button',
-            cancelButtonText: context.intl.formatMessage(swal_messages.cancelButtonText),
+            cancelButtonText: this.context.intl.formatMessage(swal_messages.cancelButtonText),
             cancelButtonClass: 'ui red button',
             buttonsStyling: false
         }).then((accepted) => {


### PR DESCRIPTION
Solves a problem with an error that occurs when reverting a slide to a previous version. 

When the revert button is clicked, the following error appears:

```
Uncaught TypeError: Cannot read property 'formatMessage' of undefined
    at ContentChangeItem.handleRevertClick (ContentChangeItem.js:32)
    at apply (_apply.js:15)
    at baseInvoke (_baseInvoke.js:21)
    at apply (_apply.js:16)
    at _overRest.js:32
    at Button.js:77
    at HTMLUnknownElement.callCallback (react-dom.development.js:188)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237)
    at invokeGuardedCallback (react-dom.development.js:292)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:306)
```

<img width="669" alt="Screen Shot 2020-05-07 at 11 17 57" src="https://user-images.githubusercontent.com/1567948/81277348-959d7b80-9054-11ea-861e-5d3d357ddd3f.png">
