### PR TITLE
fix: fork legacy deck without language

### DIFF
--- a/stores/TranslationStore.js
+++ b/stores/TranslationStore.js
@@ -89,7 +89,7 @@ class TranslationStore extends BaseStore {
         }
 
         // update translations
-        this.translations = payload.translations.filter((v) => !v.original && v.language !== null).map((cur) => cur.language.substring(0, 2));
+        this.translations = payload.translations.filter((v) => !v.original && v.language).map((cur) => cur.language.substring(0, 2));
         this.nodeVariants = payload.translations;
 
         this.emitChange();
@@ -98,7 +98,7 @@ class TranslationStore extends BaseStore {
 
     deckTreeGotLoaded(data) {
         this.treeLanguage = data.deckTree.variants.find((v) => v.original).language;
-        this.treeTranslations = data.deckTree.variants.filter((v) => !v.original && v.language !== null).map((cur) => cur.language.substring(0, 2));
+        this.treeTranslations = data.deckTree.variants.filter((v) => !v.original && v.language).map((cur) => cur.language.substring(0, 2));
 
         this.emitChange();
         // this.logState('deckTreeGotLoaded');


### PR DESCRIPTION
This forked deck is not working because a language translation is empty:

http://slidewiki.org/deck/130268-1/03-rdf-serializations/slide/851750-5/130271-1:7;851750-5:4/

This PR changes the check for null to also check if the property exists at all. 